### PR TITLE
feat: add SSR-safe Mermaid rendering factory

### DIFF
--- a/docs/superpowers/plans/2026-08-01-ssr-safe-mermaid-rendering-factory.md
+++ b/docs/superpowers/plans/2026-08-01-ssr-safe-mermaid-rendering-factory.md
@@ -1,0 +1,67 @@
+# SSR-safe Mermaid Rendering Factory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Issue #3's internal SSR-safe Mermaid rendering factory and lock its behavior with focused tests, without changing the Built-in Renderer or public package behavior.
+
+**Architecture:** Add a plain TypeScript `mermaid-rendering` module with a module-scoped FIFO. A factory receives stable loader/read/prepare/debug dependencies once and returns a zero-argument Render Request function; each dequeued request reads the latest rendering data and returns an explicit skipped, success, or failure outcome.
+
+**Tech Stack:** TypeScript, Vue `nextTick`, Mermaid types, Vitest 4, pnpm.
+
+## Global Constraints
+
+- Keep the factory internal: no package export, Nuxt injection, auto-import, public type, or extension hook.
+- Do not integrate the factory into `Mermaid.vue`; Issue #4 owns Built-in Renderer migration and old queue removal.
+- Module evaluation and factory creation must not touch DOM, `performance`, or load Mermaid.
+- Preserve the original thrown value by identity and recover the shared FIFO after failures.
+- Do not add cancellation, concurrency, coalescing, deduplication, priority, or unrelated fixes.
+
+---
+
+## Task 1: Define the request seam and SSR-safe skip behavior
+
+**Files:**
+
+- Create: `src/runtime/mermaid-rendering.ts`
+- Create: `test/mermaidRendering.test.ts`
+
+- [ ] Write focused tests that import/create the factory without browser globals and assert missing source or Render Target returns `skipped` without prepare or Mermaid loading.
+- [ ] Run `pnpm exec vitest run test/mermaidRendering.test.ts` and confirm the tests fail because the module is absent.
+- [ ] Add the smallest internal dependency and Render Outcome types plus dequeue-time validation needed to pass.
+- [ ] Re-run the focused test and typecheck.
+
+## Task 2: Implement valid Render Attempt protocol and global FIFO
+
+**Files:**
+
+- Modify: `src/runtime/mermaid-rendering.ts`
+- Modify: `test/mermaidRendering.test.ts`
+
+- [ ] Add behavior tests for latest dequeue-time source/config/target reads across different requesters and prove attempts never overlap.
+- [ ] Add an ordering test for validation, prepare, loader, initialize, source write, Vue scheduler, Mermaid run, SVG viewBox normalization, and success outcome.
+- [ ] Run the focused test and confirm the new assertions fail for the intended missing behavior.
+- [ ] Implement the module-scoped FIFO and the minimal valid-attempt protocol.
+- [ ] Re-run the focused test and typecheck.
+
+## Task 3: Implement failure recovery and debug diagnostics
+
+**Files:**
+
+- Modify: `src/runtime/mermaid-rendering.ts`
+- Modify: `test/mermaidRendering.test.ts`
+
+- [ ] Add tests for target cleanup, exact thrown-value identity, later-request recovery, and debug enqueue/start/finish/duration/failure semantics without exact message matching.
+- [ ] Run the focused test and confirm the new assertions fail.
+- [ ] Implement failure outcomes, cleanup, FIFO recovery, and diagnostic events.
+- [ ] Re-run the focused test and typecheck.
+
+## Task 4: Verify, review, and commit
+
+**Files:**
+
+- Review all files changed since baseline `0464389`.
+
+- [ ] Run `pnpm lint --fix`, the focused factory test, `pnpm test:types`, and `pnpm test`.
+- [ ] Run the module/production build required by the repository release gate.
+- [ ] Review the diff on Standards and Spec axes via the repository `code-review` skill; fix and re-run affected checks.
+- [ ] Commit the final scoped changes on the current branch using a Conventional Commit message.

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -2,6 +2,7 @@ import type { MermaidConfig } from 'mermaid'
 import type { MermaidToolbarOptions } from '../types/mermaid'
 import type { ExpandOptions } from './types/expand'
 
+export const MERMAID_LOG_PREFIX = '[nuxt-content-mermaid]'
 export const DEFAULT_LIGHT_THEME: MermaidConfig['theme'] = 'default'
 export const DEFAULT_DARK_THEME: MermaidConfig['theme'] = 'dark'
 export const DEFAULT_MERMAID_CONFIG: MermaidConfig = {

--- a/src/runtime/mermaid-rendering.ts
+++ b/src/runtime/mermaid-rendering.ts
@@ -1,0 +1,139 @@
+import type { Mermaid, MermaidConfig } from 'mermaid'
+import { nextTick } from 'vue'
+import { MERMAID_LOG_PREFIX } from './constants'
+
+let renderQueue = Promise.resolve()
+let queueSize = 0
+
+export interface MermaidRenderData {
+  source: string | null | undefined
+  config: MermaidConfig
+  target: HTMLDivElement | null | undefined
+}
+
+export type MermaidRenderOutcome
+  = | { status: 'skipped' }
+    | { status: 'success' }
+    | { status: 'failure', error: unknown }
+
+export interface MermaidRendererDependencies {
+  loadMermaid: () => Promise<Mermaid>
+  readRenderData: () => MermaidRenderData
+  prepare: () => void
+  debug: boolean
+}
+
+/** @internal */
+export function createMermaidRenderer(
+  dependencies: MermaidRendererDependencies,
+): () => Promise<MermaidRenderOutcome> {
+  return () => {
+    queueSize++
+    if (dependencies.debug) {
+      console.log(MERMAID_LOG_PREFIX, {
+        event: 'queue:enqueue',
+        queueSize,
+      })
+    }
+
+    const render = async (): Promise<MermaidRenderOutcome> => {
+      let target: HTMLDivElement | null | undefined
+      let attemptStart: number | undefined
+
+      if (dependencies.debug) {
+        console.log(MERMAID_LOG_PREFIX, {
+          event: 'queue:start',
+          pending: queueSize - 1,
+        })
+      }
+
+      try {
+        const renderData = dependencies.readRenderData()
+        const { source, config } = renderData
+        target = renderData.target
+
+        if (!source || !target)
+          return { status: 'skipped' }
+
+        if (dependencies.debug)
+          attemptStart = performance.now()
+
+        dependencies.prepare()
+
+        const mermaid = await dependencies.loadMermaid()
+        mermaid.initialize(config)
+        target.removeAttribute('data-processed')
+        target.textContent = source
+        await nextTick()
+
+        await mermaid.run({
+          nodes: [target],
+          suppressErrors: !dependencies.debug,
+        })
+
+        const svg = target.querySelector('svg')
+        if (svg)
+          ensureViewBox(svg)
+
+        return { status: 'success' }
+      }
+      catch (error) {
+        if (target) {
+          try {
+            target.innerHTML = ''
+          }
+          catch {
+            // Preserve the original failure when cleanup itself cannot complete.
+          }
+        }
+
+        if (dependencies.debug) {
+          console.error(
+            MERMAID_LOG_PREFIX,
+            { event: 'attempt:failure' },
+            error,
+          )
+        }
+
+        return { status: 'failure', error }
+      }
+      finally {
+        if (dependencies.debug && attemptStart !== undefined) {
+          console.log(MERMAID_LOG_PREFIX, {
+            event: 'attempt:duration',
+            duration: performance.now() - attemptStart,
+          })
+        }
+
+        queueSize--
+        if (dependencies.debug) {
+          console.log(MERMAID_LOG_PREFIX, {
+            event: 'queue:finish',
+            remaining: queueSize,
+          })
+        }
+      }
+    }
+
+    const outcome = renderQueue.then(render)
+    renderQueue = outcome.then(
+      () => undefined,
+      () => undefined,
+    )
+    return outcome
+  }
+}
+
+function ensureViewBox(svg: SVGSVGElement) {
+  if (svg.hasAttribute('viewBox'))
+    return
+
+  try {
+    const bbox = (svg as SVGGraphicsElement).getBBox()
+    if (bbox.width > 0 && bbox.height > 0)
+      svg.setAttribute('viewBox', `${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}`)
+  }
+  catch {
+    // Some rendered SVGs cannot provide a bounding box in the current DOM.
+  }
+}

--- a/test/mermaidRendering.test.ts
+++ b/test/mermaidRendering.test.ts
@@ -1,0 +1,354 @@
+import type { Mermaid, MermaidConfig } from 'mermaid'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { scheduler } = vi.hoisted(() => ({
+  scheduler: { events: [] as string[] },
+}))
+
+vi.mock('vue', () => ({
+  nextTick: vi.fn(async () => {
+    scheduler.events.push('scheduler')
+  }),
+}))
+
+function createTarget(events: string[], svg: SVGSVGElement | null = null) {
+  let content = ''
+
+  const target = {
+    removeAttribute: vi.fn((name: string) => {
+      events.push(`remove:${name}`)
+    }),
+    get textContent() {
+      return content
+    },
+    set textContent(value: string | null) {
+      content = value ?? ''
+      events.push(`write:${content}`)
+    },
+    get innerHTML() {
+      return content
+    },
+    set innerHTML(value: string) {
+      content = value
+      events.push(`html:${value}`)
+    },
+    querySelector: vi.fn((selector: string) => {
+      events.push(`query:${selector}`)
+      return svg
+    }),
+  } as unknown as HTMLDivElement
+
+  return {
+    target,
+    readContent: () => content,
+  }
+}
+
+function asMermaid(value: Pick<Mermaid, 'initialize' | 'run'>): Mermaid {
+  return value as Mermaid
+}
+
+describe('createMermaidRenderer', () => {
+  beforeEach(() => {
+    scheduler.events = []
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('is safe to import and create on the server, then skips without a Render Target', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.stubGlobal('document', undefined)
+    vi.stubGlobal('window', undefined)
+    vi.stubGlobal('SVGSVGElement', undefined)
+    vi.stubGlobal('performance', undefined)
+
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const loadMermaid = vi.fn()
+    const prepare = vi.fn()
+    const readRenderData = vi.fn(() => ({
+      source: 'graph TD; A-->B',
+      config: {} satisfies MermaidConfig,
+      target: null,
+    }))
+
+    const requestRender = createMermaidRenderer({
+      loadMermaid,
+      readRenderData,
+      prepare,
+      debug: true,
+    })
+
+    expect(readRenderData).not.toHaveBeenCalled()
+    expect(loadMermaid).not.toHaveBeenCalled()
+    expect(prepare).not.toHaveBeenCalled()
+
+    await expect(requestRender()).resolves.toEqual({ status: 'skipped' })
+    expect(readRenderData).toHaveBeenCalledOnce()
+    expect(loadMermaid).not.toHaveBeenCalled()
+    expect(prepare).not.toHaveBeenCalled()
+  })
+
+  it('skips an empty source before prepare or Mermaid loading', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const loadMermaid = vi.fn()
+    const prepare = vi.fn()
+    const readRenderData = vi.fn(() => ({
+      source: '',
+      config: {} satisfies MermaidConfig,
+      target: {} as HTMLDivElement,
+    }))
+
+    const requestRender = createMermaidRenderer({
+      loadMermaid,
+      readRenderData,
+      prepare,
+      debug: false,
+    })
+
+    await expect(requestRender()).resolves.toEqual({ status: 'skipped' })
+    expect(loadMermaid).not.toHaveBeenCalled()
+    expect(prepare).not.toHaveBeenCalled()
+  })
+
+  it('follows the valid Render Attempt protocol and normalizes the SVG viewBox', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const events: string[] = []
+    scheduler.events = events
+    const config = { theme: 'dark' } satisfies MermaidConfig
+    const svg = {
+      hasAttribute: vi.fn((name: string) => {
+        events.push(`has:${name}`)
+        return false
+      }),
+      getBBox: vi.fn(() => {
+        events.push('bbox')
+        return { x: 1, y: 2, width: 300, height: 200 }
+      }),
+      setAttribute: vi.fn((name: string, value: string) => {
+        events.push(`set:${name}:${value}`)
+      }),
+    } as unknown as SVGSVGElement
+    const { target } = createTarget(events, svg)
+    const mermaid = asMermaid({
+      initialize: vi.fn((receivedConfig: MermaidConfig) => {
+        expect(receivedConfig).toBe(config)
+        events.push('initialize')
+      }),
+      run: vi.fn(async (options) => {
+        expect(options).toEqual({ nodes: [target], suppressErrors: true })
+        events.push('run')
+      }),
+    })
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => {
+        events.push('read')
+        return { source: 'graph TD; A-->B', config, target }
+      },
+      prepare: () => {
+        events.push('prepare')
+      },
+      loadMermaid: async () => {
+        events.push('load')
+        return mermaid
+      },
+      debug: false,
+    })
+
+    const outcome = await requestRender()
+    events.push(outcome.status)
+
+    expect(events).toEqual([
+      'read',
+      'prepare',
+      'load',
+      'initialize',
+      'remove:data-processed',
+      'write:graph TD; A-->B',
+      'scheduler',
+      'run',
+      'query:svg',
+      'has:viewBox',
+      'bbox',
+      'set:viewBox:1 2 300 200',
+      'success',
+    ])
+  })
+
+  it('shares one FIFO and reads each requester data only when dequeued', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const events: string[] = []
+    let releaseFirst!: () => void
+    let markFirstStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const firstTarget = createTarget(events).target
+    const oldTarget = createTarget(events)
+    const latestTarget = createTarget(events)
+    const oldConfig = { theme: 'default' } satisfies MermaidConfig
+    const latestConfig = { theme: 'forest' } satisfies MermaidConfig
+    let secondData = {
+      source: 'old source',
+      config: oldConfig as MermaidConfig,
+      target: oldTarget.target,
+    }
+
+    const firstRequester = createMermaidRenderer({
+      readRenderData: () => ({ source: 'first source', config: {}, target: firstTarget }),
+      prepare: () => {},
+      loadMermaid: async () => asMermaid({
+        initialize: vi.fn(),
+        run: vi.fn(async () => {
+          events.push('first:start')
+          markFirstStarted()
+          await firstGate
+          events.push('first:finish')
+        }),
+      }),
+      debug: false,
+    })
+    const secondRead = vi.fn(() => secondData)
+    const secondInitialize = vi.fn()
+    const secondRequester = createMermaidRenderer({
+      readRenderData: secondRead,
+      prepare: () => {},
+      loadMermaid: async () => asMermaid({
+        initialize: secondInitialize,
+        run: vi.fn(async () => {
+          events.push('second')
+        }),
+      }),
+      debug: false,
+    })
+
+    const firstOutcome = firstRequester()
+    await firstStarted
+    const secondOutcome = secondRequester()
+    secondData = {
+      source: 'latest source',
+      config: latestConfig,
+      target: latestTarget.target,
+    }
+
+    await Promise.resolve()
+    expect(secondRead).not.toHaveBeenCalled()
+
+    releaseFirst()
+    await expect(Promise.all([firstOutcome, secondOutcome])).resolves.toEqual([
+      { status: 'success' },
+      { status: 'success' },
+    ])
+    expect(events.indexOf('first:finish')).toBeLessThan(events.indexOf('second'))
+    expect(secondInitialize).toHaveBeenCalledWith(latestConfig)
+    expect(oldTarget.readContent()).toBe('')
+    expect(latestTarget.readContent()).toBe('latest source')
+  })
+
+  it('preserves failures from every attempt stage, clears the target, and recovers the FIFO', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const stages = ['prepare', 'loader', 'initialize', 'run', 'normalization'] as const
+
+    for (const stage of stages) {
+      const events: string[] = []
+      const thrownValue = { stage }
+      const { target } = createTarget(events)
+
+      if (stage === 'normalization') {
+        target.querySelector = vi.fn(() => {
+          throw thrownValue
+        })
+      }
+
+      const requestRender = createMermaidRenderer({
+        readRenderData: () => ({ source: `${stage} source`, config: {}, target }),
+        prepare: () => {
+          if (stage === 'prepare') throw thrownValue
+        },
+        loadMermaid: async () => {
+          if (stage === 'loader') throw thrownValue
+
+          return asMermaid({
+            initialize: vi.fn(() => {
+              if (stage === 'initialize') throw thrownValue
+            }),
+            run: vi.fn(async () => {
+              if (stage === 'run') throw thrownValue
+            }),
+          })
+        },
+        debug: false,
+      })
+
+      const outcome = await requestRender()
+
+      expect(outcome.status).toBe('failure')
+      if (outcome.status === 'failure')
+        expect(outcome.error).toBe(thrownValue)
+      expect(events).toContain('html:')
+    }
+
+    const recoveredTarget = createTarget([])
+    const recoveredRequest = createMermaidRenderer({
+      readRenderData: () => ({ source: 'recovered', config: {}, target: recoveredTarget.target }),
+      prepare: () => {},
+      loadMermaid: async () => asMermaid({ initialize: vi.fn(), run: vi.fn() }),
+      debug: false,
+    })
+
+    await expect(recoveredRequest()).resolves.toEqual({ status: 'success' })
+    expect(recoveredTarget.readContent()).toBe('recovered')
+  })
+
+  it('reports debug diagnostics by semantic event category', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const thrownValue = new Error('debug failure')
+    const { target } = createTarget([])
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('performance', {
+      now: vi.fn()
+        .mockReturnValueOnce(100)
+        .mockReturnValueOnce(125),
+    })
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => ({ source: 'debug source', config: {}, target }),
+      prepare: () => {},
+      loadMermaid: async () => asMermaid({
+        initialize: vi.fn(),
+        run: vi.fn(async () => {
+          throw thrownValue
+        }),
+      }),
+      debug: true,
+    })
+
+    const outcome = await requestRender()
+    const diagnosticEvents = [...logSpy.mock.calls, ...errorSpy.mock.calls]
+      .flatMap(call => call)
+      .filter((value): value is { event: string } => (
+        typeof value === 'object'
+        && value !== null
+        && 'event' in value
+        && typeof value.event === 'string'
+      ))
+      .map(value => value.event)
+
+    expect(outcome.status).toBe('failure')
+    if (outcome.status === 'failure')
+      expect(outcome.error).toBe(thrownValue)
+    expect(diagnosticEvents).toEqual(expect.arrayContaining([
+      'queue:enqueue',
+      'queue:start',
+      'attempt:duration',
+      'attempt:failure',
+      'queue:finish',
+    ]))
+    expect(errorSpy.mock.calls.some(call => call.includes(thrownValue))).toBe(true)
+  })
+})


### PR DESCRIPTION
This pull request implements an internal, server-side rendering (SSR)-safe Mermaid rendering factory, including a robust test suite and supporting utilities. The new factory is designed to be internal-only, with a FIFO queue for render requests, explicit skip/success/failure outcomes, and thorough diagnostic and recovery features. The implementation is fully covered by focused tests to ensure correct behavior and resilience.

**SSR-safe Mermaid Rendering Factory Implementation:**

* [`src/runtime/mermaid-rendering.ts`](diffhunk://#diff-897adec76d6f8254c7c61d9832fecf20c333fc11178e942313179b9ca5c42247R1-R139): Implements the internal Mermaid rendering factory with a module-scoped FIFO queue, SSR-safe skip logic, explicit render attempt protocol, failure recovery, and debug diagnostics.
* [`test/mermaidRendering.test.ts`](diffhunk://#diff-a172afc0079d311b63fba7be48575d496c9f04cb7ad5578573f00ef3d4a4c19cR1-R354): Adds comprehensive tests covering SSR safety, skip behavior, render protocol, FIFO behavior, failure recovery, and debug diagnostics for the new factory.
* [`docs/superpowers/plans/2026-08-01-ssr-safe-mermaid-rendering-factory.md`](diffhunk://#diff-977523cf850bd85829be1593aee6f0814ba6fa180ef200723e4205fb6d810795R1-R67): Documents the implementation plan, architectural constraints, and step-by-step tasks for the SSR-safe Mermaid rendering factory.

**Supporting changes:**

* [`src/runtime/constants.ts`](diffhunk://#diff-0517a94e5cb14a8974f41e5671a903e45bdbd4d0e83a5ff4756460e9e0b79d77R5): Adds a `MERMAID_LOG_PREFIX` constant for consistent debug logging in the rendering factory.

Closes #3