### PR TITLE
refactor: establish internal Markdown Diagram Transform

### DIFF
--- a/docs/superpowers/plans/2026-08-02-internal-markdown-diagram-transform.md
+++ b/docs/superpowers/plans/2026-08-02-internal-markdown-diagram-transform.md
@@ -1,0 +1,149 @@
+# Internal Markdown Diagram Transform Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the Package User Markdown path through a synchronous internal body-to-body Markdown Diagram Transform that owns scanner behavior and fixed protocol values.
+
+**Architecture:** Add a build-time deep module containing the scanner and Markdown Diagram Protocol serializer. `src/module.ts` delegates to it while retaining the historical named export as a temporary bridge; established metadata helpers remain unchanged until Issue #9.
+
+**Tech Stack:** TypeScript, Nuxt Kit, Nuxt Content `content:file:beforeParse`, Vitest 4, pnpm.
+
+## Global Constraints
+
+- The semantic seam accepts only a Markdown body string and synchronously returns a body string.
+- The scanner is the sole Mermaid fence recognition authority; do not add or test a second grammar.
+- The deep module owns component identity `Mermaid` and Page Mermaid Config binding `config`.
+- Preserve observable recognition, Selective Fallback, indentation, newline, metadata, and toolbar behavior.
+- Keep the package-root transform export present; Issue #11 removes it.
+- Do not move metadata helpers or add real MDC protocol parsing coverage; Issue #9 owns that work.
+- Do not add catch-all recovery, diagnostics, I/O, state, callbacks, injection, or new public interfaces.
+
+---
+
+### Task 1: Establish the internal body-to-body behavior seam
+
+**Files:**
+
+- Create: `src/markdown-diagram-transform.ts`
+- Modify: `test/transformMermaid.test.ts`
+
+**Interfaces:**
+
+- Consumes: raw Markdown `body: string` and the existing deterministic metadata helpers.
+- Produces: `transformMarkdownDiagrams(body: string): string`, imported only by source/tests through an internal path.
+
+- [ ] **Step 1: Migrate one behavior test to the internal seam**
+
+Change the test import to `transformMarkdownDiagrams` from `../src/markdown-diagram-transform` and call it with only the Markdown body. Keep a known literal expected result containing `<Mermaid :config="config" ...>`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run `python .agents/skills/vitest/scripts/run_vitest.py --root . -- test/transformMermaid.test.ts`.
+
+Expected: FAIL because `src/markdown-diagram-transform.ts` does not exist.
+
+- [ ] **Step 3: Add the minimal deep module**
+
+Move the complete scanner and serializer from `src/module.ts` into `src/markdown-diagram-transform.ts`. Define private constants for `Mermaid` and `config`, export only `transformMarkdownDiagrams(body: string): string`, and preserve existing metadata-helper calls.
+
+- [ ] **Step 4: Run focused tests and typecheck**
+
+Run the focused Vitest helper command, then `pnpm test:types`.
+
+Expected: the migrated behavior test and both typecheck targets pass.
+
+### Task 2: Lock scanner recognition and Selective Fallback behavior
+
+**Files:**
+
+- Modify: `test/transformMermaid.test.ts`
+- Modify: `src/markdown-diagram-transform.ts`
+
+**Interfaces:**
+
+- Consumes: `transformMarkdownDiagrams(body: string): string` from Task 1.
+- Produces: representative behavioral coverage of the complete body-to-body scanner seam.
+
+- [ ] **Step 1: Add exact non-target and recognition-boundary tests**
+
+Add cases for ordinary Markdown exact equality, language names that merely start with `mermaid`, opaque backtick and tilde fences, and matching close marker character/length.
+
+- [ ] **Step 2: Run focused tests and verify RED where coverage exposes missing deep-module behavior**
+
+Run the focused Vitest helper command. Any new failure must identify an observable behavior gap at the body-to-body seam rather than a private helper call.
+
+- [ ] **Step 3: Preserve the established scanner behavior**
+
+Make only the minimal scanner changes needed to retain the existing grammar while ensuring recognition comes from the full scan. Do not add a preflight regex.
+
+- [ ] **Step 4: Add fallback and formatting cases one vertical slice at a time**
+
+Cover empty and unclosed Mermaid fences, indentation, CRLF, multiple diagrams, and established invalid metadata fallback. After each case, run the focused test before adding the next.
+
+- [ ] **Step 5: Run focused tests and typecheck**
+
+Run the focused Vitest helper command and `pnpm test:types`.
+
+Expected: all transform behavior tests and typechecking pass.
+
+### Task 3: Delegate production paths without changing export presence
+
+**Files:**
+
+- Modify: `src/module.ts`
+- Modify: `test/moduleSetup.test.ts`
+- Modify: `docs/superpowers/specs/2026-08-02-internal-markdown-diagram-transform-design.md`
+
+**Interfaces:**
+
+- Consumes: `transformMarkdownDiagrams(body: string): string`.
+- Produces: the existing Nuxt Markdown path and historical named export both route through the internal seam; package-root export presence is unchanged.
+
+- [ ] **Step 1: Strengthen the Nuxt path regression test**
+
+Keep the existing Markdown transformation assertion and non-Markdown preservation assertion. Add a scanner-recognized case that cannot be rejected by a separate semantic matcher if the adapter still retains one.
+
+- [ ] **Step 2: Run the module setup test and verify its current behavior**
+
+Run `python .agents/skills/vitest/scripts/run_vitest.py --root . -- test/moduleSetup.test.ts`.
+
+- [ ] **Step 3: Delegate to the internal seam**
+
+Import `transformMarkdownDiagrams` in `src/module.ts`, remove the scanner implementation from the module entry, and make both the Content hook and the retained `transformMermaidCodeBlocks` export delegate to it. Keep the named export present while ignoring historical protocol-value arguments so callers cannot vary module-owned constants.
+
+- [ ] **Step 4: Update the design document with any implementation-level clarification**
+
+Record only decisions discovered during TDD; do not expand into Issue #9, #10, or #11.
+
+- [ ] **Step 5: Run focused tests and typecheck**
+
+Run both focused test files and `pnpm test:types`.
+
+Expected: transform behavior, module integration, and typechecking pass.
+
+### Task 4: Verify, review, commit, and integrate
+
+**Files:**
+
+- Review all files changed from `main`.
+
+**Interfaces:**
+
+- Consumes: Tasks 1–3 and Issue #8 acceptance criteria.
+- Produces: a reviewed Conventional Commit merged locally into `main`.
+
+- [ ] **Step 1: Run final verification on the feature branch**
+
+Run `pnpm lint --fix`, the focused transform test, `pnpm test:types`, `pnpm test`, and `pnpm prepack`. Confirm every command exits zero and inspect the complete result before claiming success.
+
+- [ ] **Step 2: Review Standards and Spec axes**
+
+Use the repository `code-review` skill with fixed point `main`. Run the required Standards and Spec reviews in parallel, fix every actionable finding, and rerun affected checks.
+
+- [ ] **Step 3: Commit the feature branch**
+
+Stage only Issue #8 files and commit with `refactor: establish internal markdown diagram transform`.
+
+- [ ] **Step 4: Merge locally and verify the merged result**
+
+Switch to `main`, merge `codex/issue-8-markdown-diagram-transform` without rewriting unrelated history, rerun the complete test suite, and delete the merged feature branch only after the merged result is green.

--- a/docs/superpowers/plans/2026-08-02-internal-markdown-diagram-transform.md
+++ b/docs/superpowers/plans/2026-08-02-internal-markdown-diagram-transform.md
@@ -109,7 +109,7 @@ Run `python .agents/skills/vitest/scripts/run_vitest.py --root . -- test/moduleS
 
 - [ ] **Step 3: Delegate to the internal seam**
 
-Import `transformMarkdownDiagrams` in `src/module.ts`, remove the scanner implementation from the module entry, and make both the Content hook and the retained `transformMermaidCodeBlocks` export delegate to it. Keep the named export present while ignoring historical protocol-value arguments so callers cannot vary module-owned constants.
+Import `transformMarkdownDiagrams` in `src/module.ts`, remove the scanner implementation from the module entry, and make both the Content hook and the retained `transformMermaidCodeBlocks` export delegate to it. Keep the named export present while ignoring historical protocol-value arguments so those parameters cannot vary module-owned constants.
 
 - [ ] **Step 4: Update the design document with any implementation-level clarification**
 

--- a/docs/superpowers/specs/2026-08-02-internal-markdown-diagram-transform-design.md
+++ b/docs/superpowers/specs/2026-08-02-internal-markdown-diagram-transform-design.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Issue #8 is the first preparatory slice of Issue #7. Today the Nuxt module entry owns the Markdown fence scanner and passes fixed Markdown Diagram Protocol values into `transformMermaidCodeBlocks`, while diagram metadata helpers live under runtime utilities. This makes the Package User Markdown path depend on a shallow, caller-configurable transform shape even though production has only one valid component identity and Page Mermaid Config binding.
+Issue #8 is the first preparatory slice of Issue #7. Today the Nuxt module entry owns the Markdown fence scanner and passes fixed Markdown Diagram Protocol values into `transformMermaidCodeBlocks`, while diagram metadata helpers live under runtime utilities. This makes the Package User Markdown path depend on a shallow transform shape that exposes fixed protocol values as parameters even though production has only one valid component identity and Page Mermaid Config binding.
 
 ## Scope
 

--- a/docs/superpowers/specs/2026-08-02-internal-markdown-diagram-transform-design.md
+++ b/docs/superpowers/specs/2026-08-02-internal-markdown-diagram-transform-design.md
@@ -1,0 +1,34 @@
+# Internal Markdown Diagram Transform Design
+
+## Context
+
+Issue #8 is the first preparatory slice of Issue #7. Today the Nuxt module entry owns the Markdown fence scanner and passes fixed Markdown Diagram Protocol values into `transformMermaidCodeBlocks`, while diagram metadata helpers live under runtime utilities. This makes the Package User Markdown path depend on a shallow, caller-configurable transform shape even though production has only one valid component identity and Page Mermaid Config binding.
+
+## Scope
+
+Create a module/build-time internal Markdown Diagram Transform whose semantic interface is synchronous `body: string -> body: string`. The internal module owns Mermaid fence recognition, opaque fence boundaries, matching closing fences, empty and unclosed fallback, indentation, newline preservation, multiple-diagram traversal, non-target preservation, the `Mermaid` component identity, and the `config` Page Mermaid Config binding.
+
+The existing Nuxt `content:file:beforeParse` path delegates eligible Markdown to this internal seam. The historical package-root `transformMermaidCodeBlocks` export remains present for this preparatory slice, but it delegates to the same internal seam and cannot vary module-owned protocol values.
+
+## Architecture and Data Flow
+
+`src/markdown-diagram-transform.ts` is the deep module. It scans the complete body exactly once and treats non-Mermaid fences as opaque until a matching close. Recognized Mermaid fences are converted to Markdown Diagram Protocol markup with private protocol constants. Established metadata parsing and Selective Fallback helpers remain behaviorally unchanged in this ticket; Issue #9 will internalize that authoring path.
+
+`src/module.ts` retains Nuxt setup and package-root compatibility only. It imports the deep module, registers the fixed `Mermaid` component, delegates Markdown bodies to the internal transform, and leaves the historical named export present as a compatibility bridge until Issue #11.
+
+## Error Handling
+
+The transform adds no catch-all recovery, warning, diagnostic, callback, or I/O. Established local fallback remains limited to recognized empty, unclosed, or invalid metadata inputs. Unexpected failures propagate to the Nuxt Content build path.
+
+## Testing
+
+Behavior tests import the internal body-to-body seam. They cover representative recognition boundaries, opaque fences, closing-marker matching, empty and unclosed fences, indentation, CRLF preservation, multiple diagrams, metadata fallback, and exact equality for non-target Markdown. Tests do not target private scanner stages or a preflight optimization.
+
+The existing module setup test remains the Nuxt Integration Contract check for Markdown delegation and writeback. Focused Vitest runs and typechecking accompany each TDD slice; final verification includes lint, the complete Vitest suite, type tests, and the module production build.
+
+## Out of Scope
+
+- Moving all metadata helpers out of runtime utilities or adding real MDC protocol parsing tests; Issue #9 owns that work.
+- Reducing the Nuxt adapter to only eligibility, delegation, and writeback; Issue #10 owns that contraction.
+- Removing the package-root transform export or documenting the 3.0.0 breaking change; Issue #11 owns that work.
+- Deliberate fence grammar fixes, renderer changes, diagnostics, performance work, or new public extension points.

--- a/src/markdown-diagram-transform.ts
+++ b/src/markdown-diagram-transform.ts
@@ -15,6 +15,15 @@ import {
 const MERMAID_COMPONENT_NAME = 'Mermaid'
 const PAGE_MERMAID_CONFIG_BINDING = 'config'
 
+function isClosingFence(line: string, markerChar: '`' | '~', markerLength: number) {
+  const trimmed = line.trim()
+  if (trimmed.length < markerLength) return false
+  for (const char of trimmed) {
+    if (char !== markerChar) return false
+  }
+  return true
+}
+
 export function transformMarkdownDiagrams(body: string) {
   const newline = body.includes('\r\n') ? '\r\n' : '\n'
   const lines = body.split(newline)
@@ -24,16 +33,6 @@ export function transformMarkdownDiagrams(body: string) {
   let inFence = false
   let fenceChar: '`' | '~' | null = null
   let fenceLength = 0
-
-  const isClosingFence = (line: string) => {
-    if (!fenceChar) return false
-    const trimmed = line.trim()
-    if (trimmed.length < fenceLength) return false
-    for (const char of trimmed) {
-      if (char !== fenceChar) return false
-    }
-    return true
-  }
 
   const isFenceMarkerChar = (char: string | undefined): char is '`' | '~' =>
     char === '`' || char === '~'
@@ -93,7 +92,7 @@ export function transformMarkdownDiagrams(body: string) {
 
     if (inFence) {
       output.push(line)
-      if (isClosingFence(line)) {
+      if (fenceChar && isClosingFence(line, fenceChar, fenceLength)) {
         inFence = false
         fenceChar = null
         fenceLength = 0
@@ -120,16 +119,7 @@ export function transformMarkdownDiagrams(body: string) {
     // Find the matching closing fence (same char, at least same length).
     let closingIndex = -1
     for (let j = index + 1; j < lines.length; j++) {
-      const trimmed = lines[j]!.trim()
-      if (trimmed.length < fence.markerLength) continue
-      let isFence = true
-      for (const char of trimmed) {
-        if (char !== fence.markerChar) {
-          isFence = false
-          break
-        }
-      }
-      if (isFence) {
+      if (isClosingFence(lines[j]!, fence.markerChar, fence.markerLength)) {
         closingIndex = j
         break
       }

--- a/src/markdown-diagram-transform.ts
+++ b/src/markdown-diagram-transform.ts
@@ -1,0 +1,171 @@
+import type { MermaidToolbarOptions } from './types/mermaid'
+import {
+  applyMermaidFrontmatterOverrides,
+  extractMermaidInlineOverrides,
+  extractToolbarProps,
+  mergeToolbarProps,
+  parseInlineAttrs,
+  parseMermaidFrontmatter,
+} from './runtime/utils/mermaid-transform'
+import {
+  isNonEmptyRecord,
+  stringifyInlineValue,
+} from './runtime/utils'
+
+const MERMAID_COMPONENT_NAME = 'Mermaid'
+const PAGE_MERMAID_CONFIG_BINDING = 'config'
+
+export function transformMarkdownDiagrams(body: string) {
+  const newline = body.includes('\r\n') ? '\r\n' : '\n'
+  const lines = body.split(newline)
+  const output: string[] = []
+
+  // Track whether we're currently inside a fenced code block that is NOT a top-level mermaid fence.
+  let inFence = false
+  let fenceChar: '`' | '~' | null = null
+  let fenceLength = 0
+
+  const isClosingFence = (line: string) => {
+    if (!fenceChar) return false
+    const trimmed = line.trim()
+    if (trimmed.length < fenceLength) return false
+    for (const char of trimmed) {
+      if (char !== fenceChar) return false
+    }
+    return true
+  }
+
+  const isFenceMarkerChar = (char: string | undefined): char is '`' | '~' =>
+    char === '`' || char === '~'
+
+  const parseFence = (line: string) => {
+    let index = 0
+    while (index < line.length && (line[index] === ' ' || line[index] === '\t'))
+      index++
+
+    const indent = line.slice(0, index)
+    const markerChar = line[index]
+    if (!isFenceMarkerChar(markerChar))
+      return null
+
+    let markerEnd = index
+    while (markerEnd < line.length && line[markerEnd] === markerChar)
+      markerEnd++
+
+    const markerLength = markerEnd - index
+    if (markerLength < 3)
+      return null
+
+    return {
+      indent,
+      markerChar,
+      markerLength,
+      info: line.slice(markerEnd).trim(),
+    }
+  }
+
+  const isMermaidFence = (info: string) => {
+    // Accept "mermaid" as the fence info string and allow common MDC/MD meta:
+    // e.g. "mermaid", "mermaid {..}", "mermaid [..]".
+    if (!info) return false
+    const lower = info.toLowerCase()
+    if (!lower.startsWith('mermaid')) return false
+
+    const next = lower.slice('mermaid'.length, 'mermaid'.length + 1)
+    return next === '' || /\s/.test(next) || next === '{' || next === '['
+  }
+
+  const buildComponentTag = (encoded: string, toolbar?: MermaidToolbarOptions) => {
+    const attrs = [
+      `:config="${PAGE_MERMAID_CONFIG_BINDING}"`,
+    ]
+
+    if (toolbar && isNonEmptyRecord(toolbar)) {
+      attrs.push(`:toolbar='${stringifyInlineValue(toolbar)}'`)
+    }
+
+    attrs.push(`code="${encoded}"`)
+    return `<${MERMAID_COMPONENT_NAME} ${attrs.join(' ')}></${MERMAID_COMPONENT_NAME}>`
+  }
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]!
+
+    if (inFence) {
+      output.push(line)
+      if (isClosingFence(line)) {
+        inFence = false
+        fenceChar = null
+        fenceLength = 0
+      }
+      continue
+    }
+
+    const fence = parseFence(line)
+    if (!fence) {
+      output.push(line)
+      continue
+    }
+
+    // Only transform top-level mermaid fences; treat other fenced code blocks as opaque.
+    if (!isMermaidFence(fence.info)) {
+      // Enter an opaque fence: everything is emitted as-is until its closing fence.
+      inFence = true
+      fenceChar = fence.markerChar
+      fenceLength = fence.markerLength
+      output.push(line)
+      continue
+    }
+
+    // Find the matching closing fence (same char, at least same length).
+    let closingIndex = -1
+    for (let j = index + 1; j < lines.length; j++) {
+      const trimmed = lines[j]!.trim()
+      if (trimmed.length < fence.markerLength) continue
+      let isFence = true
+      for (const char of trimmed) {
+        if (char !== fence.markerChar) {
+          isFence = false
+          break
+        }
+      }
+      if (isFence) {
+        closingIndex = j
+        break
+      }
+    }
+
+    // If the fence is unclosed, leave it untouched.
+    if (closingIndex === -1) {
+      output.push(line)
+      continue
+    }
+
+    const rawCode = lines.slice(index + 1, closingIndex).join(newline)
+    const code = rawCode.trim()
+
+    if (!code) {
+      output.push(...lines.slice(index, closingIndex + 1))
+      index = closingIndex
+      continue
+    }
+
+    const inlineAttrs = parseInlineAttrs(fence.info)
+    const frontmatterInfo = parseMermaidFrontmatter(rawCode, newline)
+    const inlineOverrides = extractMermaidInlineOverrides(inlineAttrs)
+    const mergedCode = inlineOverrides
+      ? applyMermaidFrontmatterOverrides(rawCode, newline, frontmatterInfo, inlineOverrides, fence.indent)
+      : rawCode
+
+    const toolbarProps = mergeToolbarProps(
+      extractToolbarProps(frontmatterInfo?.data),
+      extractToolbarProps(inlineAttrs),
+    )
+
+    const encoded = encodeURIComponent(mergedCode.trim())
+    output.push(`${fence.indent}${buildComponentTag(encoded, toolbarProps)}`)
+    index = closingIndex
+  }
+
+  return output.join(newline)
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,21 +17,9 @@ import {
   DEFAULT_MERMAID_CONFIG,
   DEFAULT_TOOLBAR_OPTIONS,
   DEFAULT_EXPAND_OPTIONS,
-  DEFAULT_FRONTMATTER_CONFIG_KEY,
 } from './runtime/constants'
 import type { ExpandOptions } from './runtime/types/expand'
-import {
-  applyMermaidFrontmatterOverrides,
-  extractMermaidInlineOverrides,
-  extractToolbarProps,
-  mergeToolbarProps,
-  parseInlineAttrs,
-  parseMermaidFrontmatter,
-} from './runtime/utils/mermaid-transform'
-import {
-  isNonEmptyRecord,
-  stringifyInlineValue,
-} from './runtime/utils'
+import { transformMarkdownDiagrams } from './markdown-diagram-transform'
 import type { MermaidToolbarOptions } from './types/mermaid'
 
 const MODULE_NAME = '@barzhsieh/nuxt-content-mermaid'
@@ -283,169 +271,15 @@ export {}
       if (!file.id?.endsWith('.md')) return
       if (!MERMAID_FENCE_RE.test(file.body)) return
 
-      file.body = transformMermaidCodeBlocks(
-        file.body,
-        baseMermaidComponentName,
-      )
+      file.body = transformMarkdownDiagrams(file.body)
     })
   },
 })
 
 export function transformMermaidCodeBlocks(
   body: string,
-  componentName: string,
-  frontmatterConfigKey: string = DEFAULT_FRONTMATTER_CONFIG_KEY,
+  _componentName: string,
+  _frontmatterConfigKey?: string,
 ) {
-  const newline = body.includes('\r\n') ? '\r\n' : '\n'
-  const lines = body.split(newline)
-  const output: string[] = []
-
-  // Track whether we're currently inside a fenced code block that is NOT a top-level mermaid fence.
-  let inFence = false
-  let fenceChar: '`' | '~' | null = null
-  let fenceLength = 0
-
-  const isClosingFence = (line: string) => {
-    if (!fenceChar) return false
-    const trimmed = line.trim()
-    if (trimmed.length < fenceLength) return false
-    for (const char of trimmed) {
-      if (char !== fenceChar) return false
-    }
-    return true
-  }
-
-  const isFenceMarkerChar = (char: string | undefined): char is '`' | '~' =>
-    char === '`' || char === '~'
-
-  const parseFence = (line: string) => {
-    let index = 0
-    while (index < line.length && (line[index] === ' ' || line[index] === '\t'))
-      index++
-
-    const indent = line.slice(0, index)
-    const markerChar = line[index]
-    if (!isFenceMarkerChar(markerChar))
-      return null
-
-    let markerEnd = index
-    while (markerEnd < line.length && line[markerEnd] === markerChar)
-      markerEnd++
-
-    const markerLength = markerEnd - index
-    if (markerLength < 3)
-      return null
-
-    return {
-      indent,
-      markerChar,
-      markerLength,
-      info: line.slice(markerEnd).trim(),
-    }
-  }
-
-  const isMermaidFence = (info: string) => {
-    // Accept "mermaid" as the fence info string and allow common MDC/MD meta:
-    // e.g. "mermaid", "mermaid {..}", "mermaid [..]".
-    if (!info) return false
-    const lower = info.toLowerCase()
-    if (!lower.startsWith('mermaid')) return false
-
-    const next = lower.slice('mermaid'.length, 'mermaid'.length + 1)
-    return next === '' || /\s/.test(next) || next === '{' || next === '['
-  }
-
-  const buildComponentTag = (encoded: string, toolbar?: MermaidToolbarOptions) => {
-    const attrs = [
-      `:config="${frontmatterConfigKey}"`,
-    ]
-
-    if (toolbar && isNonEmptyRecord(toolbar)) {
-      attrs.push(`:toolbar='${stringifyInlineValue(toolbar)}'`)
-    }
-
-    attrs.push(`code="${encoded}"`)
-    return `<${componentName} ${attrs.join(' ')}></${componentName}>`
-  }
-
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index]!
-
-    if (inFence) {
-      output.push(line)
-      if (isClosingFence(line)) {
-        inFence = false
-        fenceChar = null
-        fenceLength = 0
-      }
-      continue
-    }
-
-    const fence = parseFence(line)
-    if (!fence) {
-      output.push(line)
-      continue
-    }
-
-    // Only transform top-level mermaid fences; treat other fenced code blocks as opaque.
-    if (!isMermaidFence(fence.info)) {
-      // Enter an opaque fence: everything is emitted as-is until its closing fence.
-      inFence = true
-      fenceChar = fence.markerChar
-      fenceLength = fence.markerLength
-      output.push(line)
-      continue
-    }
-
-    // Find the matching closing fence (same char, at least same length).
-    let closingIndex = -1
-    for (let j = index + 1; j < lines.length; j++) {
-      const trimmed = lines[j]!.trim()
-      if (trimmed.length < fence.markerLength) continue
-      let isFence = true
-      for (const char of trimmed) {
-        if (char !== fence.markerChar) {
-          isFence = false
-          break
-        }
-      }
-      if (isFence) {
-        closingIndex = j
-        break
-      }
-    }
-
-    // If the fence is unclosed, leave it untouched.
-    if (closingIndex === -1) {
-      output.push(line)
-      continue
-    }
-
-    const rawCode = lines.slice(index + 1, closingIndex).join(newline)
-    const code = rawCode.trim()
-
-    if (!code) {
-      output.push(...lines.slice(index, closingIndex + 1))
-      index = closingIndex
-      continue
-    }
-
-    const inlineAttrs = parseInlineAttrs(fence.info)
-    const frontmatterInfo = parseMermaidFrontmatter(rawCode, newline)
-    const inlineOverrides = extractMermaidInlineOverrides(inlineAttrs)
-    const mergedCode = inlineOverrides
-      ? applyMermaidFrontmatterOverrides(rawCode, newline, frontmatterInfo, inlineOverrides, fence.indent)
-      : rawCode
-
-    const toolbarProps = mergeToolbarProps(
-      extractToolbarProps(frontmatterInfo?.data),
-      extractToolbarProps(inlineAttrs),
-    )
-
-    const encoded = encodeURIComponent(mergedCode.trim())
-    output.push(`${fence.indent}${buildComponentTag(encoded, toolbarProps)}`)
-    index = closingIndex
-  }
-
-  return output.join(newline)
+  return transformMarkdownDiagrams(body)
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,7 +47,7 @@ const MERMAID_OPTIMIZE_DEPS = [
   'dayjs/plugin/duration.js',
 ]
 
-const MERMAID_FENCE_RE = /^[ \t]*(?:`{3,}|~{3,})[ \t]*mermaid(?:$|[ \t{[])/im
+const MERMAID_CANDIDATE_RE = /mermaid/i
 
 export interface ModuleOptions {
   /**
@@ -269,7 +269,7 @@ export {}
       const { file } = ctx
 
       if (!file.id?.endsWith('.md')) return
-      if (!MERMAID_FENCE_RE.test(file.body)) return
+      if (!MERMAID_CANDIDATE_RE.test(file.body)) return
 
       file.body = transformMarkdownDiagrams(file.body)
     })

--- a/test/moduleSetup.test.ts
+++ b/test/moduleSetup.test.ts
@@ -154,6 +154,14 @@ describe('module setup', () => {
     await beforeParse(tildeCtx)
     expect(tildeCtx.file.body).toContain('<Mermaid :config="config" code="A%20--%3E%20B"></Mermaid>')
 
+    const unicodeWhitespaceCtx = createFileCtx(
+      '/test/sample-unicode-whitespace.md',
+      '```\u00A0mermaid\nA --> B\n```',
+    )
+
+    await beforeParse(unicodeWhitespaceCtx)
+    expect(unicodeWhitespaceCtx.file.body).toContain('<Mermaid :config="config" code="A%20--%3E%20B"></Mermaid>')
+
     const nonMarkdownCtx = createFileCtx(
       '/test/sample.txt',
       '```mermaid\nA --> B\n```',

--- a/test/transformMermaid.test.ts
+++ b/test/transformMermaid.test.ts
@@ -3,9 +3,9 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { parse as parseYaml } from 'yaml'
-import { transformMermaidCodeBlocks } from '../src/module'
+import { transformMarkdownDiagrams } from '../src/markdown-diagram-transform'
 
-describe('transformMermaidCodeBlocks', () => {
+describe('transformMarkdownDiagrams', () => {
   const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), 'fixtures/transform')
 
   const loadFixture = (name: string) => {
@@ -44,14 +44,14 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
 
     expect(output).toContain('<Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
   })
 
   it('transforms multiple mermaid blocks in a single document', () => {
     const body = loadFixture('multiple-blocks.md')
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
 
     const matches = output.match(/<Mermaid :config="config" code="/g) || []
     expect(matches.length).toBe(2)
@@ -66,8 +66,77 @@ describe('transformMermaidCodeBlocks', () => {
       '```',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).toBe(body)
+  })
+
+  it('preserves non-target Markdown exactly', () => {
+    const body = [
+      '# Document',
+      '',
+      'Text with `inline code` and trailing spaces.  ',
+      '',
+      '```typescript',
+      'const diagram = "mermaid"',
+      '```',
+      '',
+    ].join('\n')
+
+    expect(transformMarkdownDiagrams(body)).toBe(body)
+  })
+
+  it('does not recognize language names that only start with mermaid', () => {
+    const body = [
+      '```mermaidjs',
+      'graph TD',
+      '  A --> B',
+      '```',
+    ].join('\n')
+
+    expect(transformMarkdownDiagrams(body)).toBe(body)
+  })
+
+  it('leaves unclosed mermaid fences untouched', () => {
+    const body = [
+      '# Diagram',
+      '```mermaid',
+      'graph TD',
+      '  A --> B',
+    ].join('\n')
+
+    expect(transformMarkdownDiagrams(body)).toBe(body)
+  })
+
+  it('matches closing fences by marker character and minimum length', () => {
+    const body = [
+      '````mermaid',
+      'graph TD',
+      '```',
+      '  A --> B',
+      '~~~~',
+      '  B --> C',
+      '`````',
+    ].join('\n')
+
+    const output = transformMarkdownDiagrams(body)
+
+    expect(extractDecodedCode(output)).toBe([
+      'graph TD',
+      '```',
+      '  A --> B',
+      '~~~~',
+      '  B --> C',
+    ].join('\n'))
+  })
+
+  it('propagates unexpected transformation failures', () => {
+    const body = [
+      '```mermaid',
+      '\uD800',
+      '```',
+    ].join('\n')
+
+    expect(() => transformMarkdownDiagrams(body)).toThrow()
   })
 
   it('transforms mermaid fences with info string attributes', () => {
@@ -80,7 +149,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).toContain('<Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
   })
 
@@ -98,7 +167,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(extractJsonProp(output, ':toolbar')).toEqual({
       title: 'Mermaid 1',
       fontSize: '24px',
@@ -119,7 +188,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(extractJsonProp(output, ':toolbar')).toEqual({
       title: 'Mermaid 2',
       fullscreenToolbarScale: 1.5,
@@ -138,7 +207,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     const decoded = extractDecodedCode(output)
 
     expect(decoded).toBe([
@@ -166,7 +235,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).not.toContain(':toolbar=')
   })
 
@@ -179,7 +248,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(extractJsonProp(output, ':toolbar')).toEqual({
       title: 'Safe Title',
     })
@@ -195,7 +264,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(extractJsonProp(output, ':toolbar')).toEqual({
       fontSize: '16',
     })
@@ -220,7 +289,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
 
     expect(extractJsonProp(output, ':toolbar')).toEqual({
       title: 'YAML Toolbar',
@@ -264,7 +333,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     const decoded = extractDecodedCode(output)
 
     expect(decoded.startsWith('---\n')).toBe(true)
@@ -298,7 +367,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).toContain('  <Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
   })
 
@@ -315,7 +384,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).toBe(body)
   })
 
@@ -332,7 +401,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).toBe(body)
   })
 
@@ -345,7 +414,7 @@ describe('transformMermaidCodeBlocks', () => {
       '',
     ].join('\r\n')
 
-    const output = transformMermaidCodeBlocks(body, 'Mermaid')
+    const output = transformMarkdownDiagrams(body)
     expect(output).toContain('graph%20TD%0D%0A%20%20A%20--%3E%20B')
     expect(output).not.toMatch(/(^|[^\r])\n/)
   })


### PR DESCRIPTION
## Summary

- add a synchronous internal body-to-body Markdown Diagram Transform
- make the scanner the semantic authority and move fixed protocol values into the deep module
- preserve recognition, fallback, formatting, and non-target Markdown behavior
- retain the legacy package-root transform export for the later contraction ticket

## Tests

- `pnpm lint --fix`
- `pnpm test:types`
- `pnpm exec vitest run --exclude ".agents/**" --no-file-parallelism` (14 files, 74 tests)
- `pnpm prepack`

Closes #8