### PR TITLE
refactor: reduce Nuxt Content hook to thin adapter

### DIFF
--- a/docs/superpowers/specs/2026-08-02-thin-content-adapter-design.md
+++ b/docs/superpowers/specs/2026-08-02-thin-content-adapter-design.md
@@ -1,0 +1,47 @@
+# Thin Nuxt Content Adapter Design
+
+## Context
+
+Issue #10 narrows the Nuxt Content `content:file:beforeParse` integration after
+Issue #8 established the internal Markdown Diagram Transform. The Nuxt
+Integration Contract remains unchanged for Package Users, but the hook must not
+maintain a second Mermaid-recognition rule before delegating to the transform.
+
+## Adapter Ownership
+
+The Nuxt Content adapter owns exactly three actions:
+
+1. Determine Markdown eligibility from a `.md` file id.
+2. Pass the complete eligible `file.body` to `transformMarkdownDiagrams`.
+3. Assign the transform's exact return value to `file.body`.
+
+Non-Markdown files are left unchanged and do not invoke the transform. The
+adapter does not inspect body content, normalize Markdown, select fallbacks, or
+handle transform errors. An unexpected transform failure therefore propagates
+through the Nuxt Content build path.
+
+## Semantic Authority
+
+`src/markdown-diagram-transform.ts` is the sole Mermaid recognition semantic
+authority. It owns scanner grammar, opaque fence handling, metadata precedence,
+Selective Fallback, and Markdown Diagram Protocol output. The adapter has no
+candidate regex or other hook-boundary preflight matcher that could reject a
+Markdown body the scanner would recognize.
+
+## Testing
+
+The adapter test mocks the internal transform module boundary and observes only
+the Nuxt Content contract: `.md` eligibility, complete-body delegation, exact
+writeback, and failure propagation. Scanner, metadata, Selective Fallback, and
+serialization behavior remain covered by the Markdown Diagram Transform tests.
+Existing `enabled: false` coverage remains the module-enable regression check;
+the package's rendering paths are unchanged.
+
+## Boundaries
+
+- Issue #9 owns metadata-helper internalization. This ticket does not move or
+  refactor metadata helpers.
+- Issue #11 owns removal of the package-root `transformMermaidCodeBlocks`
+  compatibility export. This ticket leaves that entry intact.
+- Renderer, theme, toolbar, diagnostics, performance, and public extension
+  points are out of scope.

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,8 +47,6 @@ const MERMAID_OPTIMIZE_DEPS = [
   'dayjs/plugin/duration.js',
 ]
 
-const MERMAID_CANDIDATE_RE = /mermaid/i
-
 export interface ModuleOptions {
   /**
    * Whether to enable the entire Mermaid process
@@ -269,7 +267,6 @@ export {}
       const { file } = ctx
 
       if (!file.id?.endsWith('.md')) return
-      if (!MERMAID_CANDIDATE_RE.test(file.body)) return
 
       file.body = transformMarkdownDiagrams(file.body)
     })

--- a/test/moduleSetup.test.ts
+++ b/test/moduleSetup.test.ts
@@ -8,6 +8,7 @@ const addTypeTemplate = vi.fn()
 const addVitePlugin = vi.fn()
 const addImports = vi.fn()
 const loggerWarn = vi.fn()
+const transformMarkdownDiagrams = vi.fn<(body: string) => string>()
 
 vi.mock('@nuxt/kit', () => ({
   defineNuxtModule: (config: unknown) => config,
@@ -22,6 +23,10 @@ vi.mock('@nuxt/kit', () => ({
   useLogger: () => ({
     warn: loggerWarn,
   }),
+}))
+
+vi.mock('../src/markdown-diagram-transform', () => ({
+  transformMarkdownDiagrams,
 }))
 
 interface NuxtStub {
@@ -77,7 +82,7 @@ describe('module setup', () => {
     expect(Object.keys(hooks)).toHaveLength(0)
   })
 
-  it('registers hooks and transforms only markdown files with content', async () => {
+  it('registers module hooks', async () => {
     const mod = await import('../src/module')
     const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
     const { nuxt, hooks } = createNuxtStub()
@@ -116,66 +121,69 @@ describe('module setup', () => {
     const serverConfig: Record<string, unknown> = {}
     optimizeDepsPlugin.configEnvironment?.('server', serverConfig)
     expect(serverConfig.optimizeDeps).toBeUndefined()
+  })
+
+  it('delegates every Markdown body and writes back the exact transform result', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt, hooks } = createNuxtStub()
+    const body = '# Original document'
+    const transformedBody = '<!-- transform sentinel -->'
+
+    transformMarkdownDiagrams.mockReturnValue(transformedBody)
+
+    await moduleDef.setup?.({}, nuxt)
 
     const beforeParse = hooks['content:file:beforeParse']?.[0]
     if (!beforeParse)
       throw new Error('content:file:beforeParse hook not registered')
 
-    const markdownCtx = createFileCtx(
-      '/test/sample.md',
-      [
-        '# Title',
-        '```mermaid',
-        'A --> B',
-        '```',
-        '',
-        '```mermaid',
-        'B --> C',
-        '```',
-      ].join('\n'),
-    )
+    const markdownCtx = createFileCtx('/test/sample.md', body)
 
     await beforeParse(markdownCtx)
 
-    const matches = markdownCtx.file.body?.match(/<Mermaid :config="config" code="/g) || []
-    expect(matches.length).toBe(2)
+    expect(transformMarkdownDiagrams).toHaveBeenCalledOnce()
+    expect(transformMarkdownDiagrams).toHaveBeenCalledWith(body)
+    expect(markdownCtx.file.body).toBe(transformedBody)
+  })
 
-    const tildeCtx = createFileCtx(
-      '/test/sample-tilde.md',
-      [
-        '# Title',
-        '~~~mermaid',
-        'A --> B',
-        '~~~',
-        '',
-      ].join('\n'),
-    )
+  it('leaves non-Markdown bodies untouched without delegating', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt, hooks } = createNuxtStub()
+    const body = 'opaque source'
 
-    await beforeParse(tildeCtx)
-    expect(tildeCtx.file.body).toContain('<Mermaid :config="config" code="A%20--%3E%20B"></Mermaid>')
+    await moduleDef.setup?.({}, nuxt)
 
-    const unicodeWhitespaceCtx = createFileCtx(
-      '/test/sample-unicode-whitespace.md',
-      '```\u00A0mermaid\nA --> B\n```',
-    )
+    const beforeParse = hooks['content:file:beforeParse']?.[0]
+    if (!beforeParse)
+      throw new Error('content:file:beforeParse hook not registered')
 
-    await beforeParse(unicodeWhitespaceCtx)
-    expect(unicodeWhitespaceCtx.file.body).toContain('<Mermaid :config="config" code="A%20--%3E%20B"></Mermaid>')
+    const sourceCtx = createFileCtx('/test/source.txt', body)
 
-    const nonMarkdownCtx = createFileCtx(
-      '/test/sample.txt',
-      '```mermaid\nA --> B\n```',
-    )
+    await beforeParse(sourceCtx)
 
-    await beforeParse(nonMarkdownCtx)
-    expect(nonMarkdownCtx.file.body).toBe('```mermaid\nA --> B\n```')
+    expect(transformMarkdownDiagrams).not.toHaveBeenCalled()
+    expect(sourceCtx.file.body).toBe(body)
+  })
 
-    const emptyDiagramCtx = createFileCtx(
-      '/test/empty.md',
-      '```mermaid\n   \n```',
-    )
+  it('propagates unexpected transform failures', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt, hooks } = createNuxtStub()
 
-    await beforeParse(emptyDiagramCtx)
-    expect(emptyDiagramCtx.file.body).toBe('```mermaid\n   \n```')
+    transformMarkdownDiagrams.mockImplementation(() => {
+      throw new Error('unexpected transform failure')
+    })
+
+    await moduleDef.setup?.({}, nuxt)
+
+    const beforeParse = hooks['content:file:beforeParse']?.[0]
+    if (!beforeParse)
+      throw new Error('content:file:beforeParse hook not registered')
+
+    const markdownCtx = createFileCtx('/test/sample.md', '# Original document')
+
+    expect(() => beforeParse(markdownCtx)).toThrow()
   })
 })


### PR DESCRIPTION
## Summary

- Reduce the Nuxt Content `content:file:beforeParse` hook to `.md` eligibility, full-body delegation, and exact `file.body` writeback.
- Remove the hook-boundary Mermaid candidate matcher so the Markdown Diagram Transform scanner is the sole recognition authority.
- Replace adapter-level scanner/serialization assertions with focused mocked-boundary contract coverage and add Issue #10 design notes.

## Acceptance coverage

- Markdown delegates the complete body and receives the transform exact returned body.
- Non-Markdown bodies remain unchanged and never invoke the transform.
- Unexpected transform failures propagate through the hook.
- Existing `enabled: false` regression coverage remains; renderer paths and the package-root compatibility export are unchanged.

## Validation

- `pnpm lint --fix` — passed
- `pnpm exec vitest run test/moduleSetup.test.ts test/transformMermaid.test.ts` — passed (26 tests)
- `pnpm test` — passed locally
- `pnpm prepack` — passed locally
- `pnpm test:types` — blocked by a pre-existing root hook typing error at unchanged `src/module.ts:266` (`content:file:beforeParse` is absent from generated `NuxtHooks`); no Issue #10 diff touches that line typing surface.

## Parallel boundaries

- Issue #9 retains ownership of metadata-helper internalization; this PR does not move or refactor metadata helpers.
- Issue #11 retains ownership of removing `transformMermaidCodeBlocks`; this PR leaves the package-root compatibility export intact.

Closes #10