### PR TITLE
refactor: internalize Mermaid diagram metadata

### DIFF
--- a/docs/superpowers/plans/2026-08-02-internalize-diagram-metadata.md
+++ b/docs/superpowers/plans/2026-08-02-internalize-diagram-metadata.md
@@ -1,0 +1,91 @@
+# Internalize Diagram Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the internal Markdown Diagram Transform own per-diagram metadata and verify the emitted Markdown Diagram Protocol through real MDC parsing.
+
+**Architecture:** Keep `src/markdown-diagram-transform.ts` as the stable body-to-body entry. Move metadata parsing and merging into an internal sibling, keep protocol serialization private to the deep module, and remove transformation exports from app-runtime utilities.
+
+**Tech Stack:** TypeScript, Nuxt Content 3, `@nuxtjs/mdc` parser, YAML, defu, destr, Vitest 4, pnpm.
+
+## Global Constraints
+
+- Preserve metadata parsing, precedence, toolbar semantics, unsafe-key filtering, and Selective Fallback without deliberate behavior change.
+- Keep Page Mermaid Config independent and emit only the existing `config` binding.
+- Do not modify `src/module.ts`, remove the package-root transform export, or change renderer behavior.
+- Do not snapshot complete markup or constrain serializer spelling.
+- Unexpected failures must propagate.
+
+---
+
+### Task 1: Characterize the complete per-diagram authoring path
+
+**Files:**
+
+- Modify: `test/transformMermaid.test.ts`
+- Test: `test/transformMermaid.test.ts`
+
+**Interfaces:**
+
+- Consumes: `transformMarkdownDiagrams(body: string): string`.
+- Produces: body-to-body behavior coverage for precedence, toolbar projection, unsafe paths, local fallback, and unexpected failures.
+
+- [ ] Add one representative seam test that combines YAML toolbar values, inline overrides, nested config merge, and unsafe inline paths.
+- [ ] Run the focused test against a temporary protocol mutation and confirm it fails, then restore the protocol value before production edits.
+- [ ] Run `pnpm exec vitest run test/transformMermaid.test.ts` and `pnpm test:types` after restoration.
+
+### Task 2: Relocate metadata into the deep module
+
+**Files:**
+
+- Create: `src/markdown-diagram-transform/metadata.ts`
+- Modify: `src/markdown-diagram-transform.ts`
+- Delete: `src/runtime/utils/mermaid-transform.ts`
+- Modify: `src/runtime/utils/index.ts`
+- Test: `test/transformMermaid.test.ts`
+
+**Interfaces:**
+
+- Consumes: raw fence info, raw Mermaid source, newline spelling, and fence indentation.
+- Produces: private metadata parsing/merging results used only by `transformMarkdownDiagrams`.
+
+- [ ] Move the existing deterministic metadata implementation without changing parser or merge semantics.
+- [ ] Move transform-only attribute serialization out of the runtime utilities barrel.
+- [ ] Import the internal sibling only from the stable deep-module entry and remove the runtime barrel export.
+- [ ] Run the focused transform test and `pnpm test:types`.
+
+### Task 3: Verify the Markdown Diagram Protocol through real MDC parsing
+
+**Files:**
+
+- Create: `test/markdownDiagramProtocol.test.ts`
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+
+**Interfaces:**
+
+- Consumes: transformed Markdown and `parseMarkdown` from `@nuxtjs/mdc/runtime`.
+- Produces: normalized semantic assertions over parser nodes and props.
+
+- [ ] Add `@nuxtjs/mdc` as an explicit test dependency at the version used by Nuxt Content.
+- [ ] Parse a representative page containing Page Mermaid Config plus YAML and inline per-diagram metadata.
+- [ ] Assert component identity, decoded diagram source/frontmatter semantics, independent page config data, config binding, and toolbar props.
+- [ ] Parse invalid Mermaid YAML Frontmatter and assert the representative local fallback without matching complete markup.
+- [ ] Run the protocol test, combined focused tests, and `pnpm test:types`.
+
+### Task 4: Verify, review, and deliver
+
+**Files:**
+
+- Review all changes from `origin/main`.
+
+**Interfaces:**
+
+- Consumes: Issue #9 acceptance criteria and the complete feature diff.
+- Produces: a reviewed commit and PR from `codex/issue-9-internalize-diagram-metadata`.
+
+- [ ] Run `pnpm lint --fix`, focused transform/protocol tests, `pnpm test:types`, `pnpm test`, and `pnpm prepack`.
+- [ ] If the documented local Vitest collection or Nuxt parallel-start failure occurs, run `pnpm exec vitest run --exclude '.agents/**' --no-file-parallelism` and record both outcomes.
+- [ ] Run the repository `code-review` skill with `origin/main` as fixed point, fix findings, and rerun affected verification.
+- [ ] Commit with a Conventional Commit, push the exact branch, create a `main` PR with `Closes #9`, wait for CI, and use exact-head confirmation before landing.
+

--- a/docs/superpowers/specs/2026-08-02-internalize-diagram-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-02-internalize-diagram-metadata-design.md
@@ -1,0 +1,61 @@
+# Internalize Diagram Metadata Design
+
+## Context
+
+Issue #9 is the metadata-ownership slice of Issue #7. Issue #8 established
+`src/markdown-diagram-transform.ts` as the stable internal body-to-body entry,
+but the Mermaid YAML Frontmatter and Mermaid Inline Attributes implementation
+still lives under `src/runtime/utils`. That makes build-time parsing and
+serialization appear to be an app-runtime capability.
+
+## Deep-module ownership
+
+`src/markdown-diagram-transform.ts` remains the only semantic entry. Internal
+sibling code may implement per-diagram metadata parsing, precedence, toolbar
+projection, unsafe-key filtering, and frontmatter serialization, but it is not
+exported from the runtime utilities barrel or the package root.
+
+The established behavior is preserved:
+
+- Mermaid Inline Attributes override the corresponding Mermaid YAML
+  Frontmatter values.
+- Nested `config` and `toolbar` records retain their established deep merge.
+- Toolbar props are projected independently from the encoded diagram source.
+- Unsafe inline path segments (`__proto__`, `prototype`, and `constructor`)
+  remain ignored.
+- Invalid recognized metadata follows the established local fallback, while
+  unexpected failures propagate.
+
+Page Mermaid Config remains a separate runtime channel. The transform emits
+the existing `:config="config"` binding and does not parse or merge the page
+value.
+
+## Markdown Diagram Protocol verification
+
+Protocol tests pass transformed Markdown through the real parser exported by
+`@nuxtjs/mdc/runtime`, the MDC implementation used by Nuxt Content. Assertions
+normalize the parser result and verify:
+
+- the Mermaid component identity;
+- decoded diagram source and merged per-diagram frontmatter;
+- the Page Mermaid Config binding and independently parsed page data;
+- toolbar props; and
+- invalid-frontmatter fallback.
+
+The tests do not snapshot complete generated markup or constrain attribute
+order, quote style, key order, whitespace, or equivalent encoding.
+
+## Selective Fallback
+
+The relocation preserves the current local catches around YAML and structured
+inline parsing. The body-to-body entry does not add a per-fence or
+whole-document catch. Encoding and other unexpected failures therefore remain
+Content build failures.
+
+## Out of scope
+
+- The Nuxt Content hook in `src/module.ts` (Issue #10).
+- The package-root `transformMermaidCodeBlocks` export (Issue #11).
+- Fence grammar changes, new syntax, renderer behavior, diagnostics,
+  dependency migration, performance work, or new extension points.
+

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@nuxt/module-builder": "catalog:dev",
     "@nuxt/schema": "catalog:integrations",
     "@nuxt/test-utils": "catalog:test",
+    "@nuxtjs/mdc": "catalog:integrations",
     "@nuxtjs/color-mode": "catalog:dev",
     "@types/node": "catalog:types",
     "changelogen": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ catalogs:
     '@nuxt/schema':
       specifier: 4.3.1
       version: 4.3.1
+    '@nuxtjs/mdc':
+      specifier: ^0.20.1
+      version: 0.20.1
     mermaid:
       specifier: ^11.12.3
       version: 11.12.3
@@ -111,6 +114,9 @@ importers:
       '@nuxtjs/color-mode':
         specifier: catalog:dev
         version: 4.0.0(magicast@0.5.2)
+      '@nuxtjs/mdc':
+        specifier: catalog:integrations
+        version: 0.20.1(magicast@0.5.2)
       '@types/node':
         specifier: catalog:types
         version: 25.3.0
@@ -153,6 +159,8 @@ importers:
         version: 4.3.1(@parcel/watcher@2.5.1)(@types/node@25.3.0)(@vue/compiler-sfc@3.5.28)(better-sqlite3@12.4.6)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.6))(eslint@10.0.1(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.59.0)(terser@5.44.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/basic: {}
+
+  test/fixtures/built-in-renderer: {}
 
   test/fixtures/color-mode: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalogs:
     '@nuxt/content': ^3.11.2
     '@nuxt/kit': 4.3.1
     '@nuxt/schema': 4.3.1
+    '@nuxtjs/mdc': ^0.20.1
     mermaid: ^11.12.3
   test:
     '@nuxt/test-utils': ^4.0.0

--- a/src/markdown-diagram-transform.ts
+++ b/src/markdown-diagram-transform.ts
@@ -6,14 +6,19 @@ import {
   mergeToolbarProps,
   parseInlineAttrs,
   parseMermaidFrontmatter,
-} from './runtime/utils/mermaid-transform'
-import {
-  isNonEmptyRecord,
-  stringifyInlineValue,
-} from './runtime/utils'
+} from './markdown-diagram-transform/metadata'
+import { isNonEmptyRecord } from './runtime/utils/is'
 
 const MERMAID_COMPONENT_NAME = 'Mermaid'
 const PAGE_MERMAID_CONFIG_BINDING = 'config'
+
+function stringifyInlineValue(value: Record<string, unknown>) {
+  return JSON.stringify(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&#39;')
+}
 
 function isClosingFence(line: string, markerChar: '`' | '~', markerLength: number) {
   const trimmed = line.trim()

--- a/src/markdown-diagram-transform.ts
+++ b/src/markdown-diagram-transform.ts
@@ -12,7 +12,7 @@ import { isNonEmptyRecord } from './runtime/utils/is'
 const MERMAID_COMPONENT_NAME = 'Mermaid'
 const PAGE_MERMAID_CONFIG_BINDING = 'config'
 
-function stringifyInlineValue(value: Record<string, unknown>) {
+function serializeInlineAttributeRecord(value: Record<string, unknown>) {
   return JSON.stringify(value)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -85,7 +85,7 @@ export function transformMarkdownDiagrams(body: string) {
     ]
 
     if (toolbar && isNonEmptyRecord(toolbar)) {
-      attrs.push(`:toolbar='${stringifyInlineValue(toolbar)}'`)
+      attrs.push(`:toolbar='${serializeInlineAttributeRecord(toolbar)}'`)
     }
 
     attrs.push(`code="${encoded}"`)

--- a/src/markdown-diagram-transform/metadata.ts
+++ b/src/markdown-diagram-transform/metadata.ts
@@ -1,7 +1,7 @@
 import { defu } from 'defu'
 import destr from 'destr'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
-import { isNonEmptyRecord, isRecord } from './is'
+import { isNonEmptyRecord, isRecord } from '../runtime/utils/is'
 
 // Prevent prototype pollution via inline attribute paths.
 const UNSAFE_INLINE_KEYS = new Set(['__proto__', 'prototype', 'constructor'])

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -131,18 +131,5 @@ export function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
-export function escapeHtmlAttribute(value: string) {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/'/g, '&#39;')
-}
-
-export function stringifyInlineValue(value: Record<string, unknown>) {
-  return escapeHtmlAttribute(JSON.stringify(value))
-}
-
 export * from './is'
 export * from './vue'
-export * from './mermaid-transform'

--- a/test/markdownDiagramProtocol.test.ts
+++ b/test/markdownDiagramProtocol.test.ts
@@ -24,12 +24,16 @@ async function parseProtocol(markdown: string) {
 }
 
 function parseDiagramFrontmatter(source: string) {
-  const match = source.replace(/\r\n/g, '\n').match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
-  expect(match).not.toBeNull()
+  const lines = source.replace(/\r\n/g, '\n').split('\n')
+  const startIndex = lines.findIndex(line => line.trim() === '---')
+  const endIndex = lines.findIndex((line, index) => index > startIndex && line.trim() === '---')
+
+  expect(startIndex).toBe(0)
+  expect(endIndex).toBeGreaterThan(startIndex)
 
   return {
-    data: parseYaml(match?.[1] || '') as Record<string, unknown>,
-    diagram: match?.[2] || '',
+    data: parseYaml(lines.slice(startIndex + 1, endIndex).join('\n')) as Record<string, unknown>,
+    diagramLines: lines.slice(endIndex + 1).map(line => line.trim()).filter(Boolean),
   }
 }
 
@@ -97,10 +101,10 @@ describe('Markdown Diagram Protocol', () => {
         },
       },
     })
-    expect(diagram.diagram).toBe([
+    expect(diagram.diagramLines).toEqual([
       'graph TD',
-      '  A --> B',
-    ].join('\n'))
+      'A --> B',
+    ])
   })
 
   it('preserves invalid Mermaid YAML Frontmatter as a local fallback', async () => {
@@ -117,13 +121,13 @@ describe('Markdown Diagram Protocol', () => {
 
     const protocol = await parseProtocol(markdown)
 
-    expect(protocol.source).toBe([
+    expect(protocol.source.replace(/\r\n/g, '\n').split('\n').map(line => line.trim()).filter(Boolean)).toEqual([
       '---',
       'title: [invalid',
       '---',
       'graph TD',
-      '  A --> B',
-    ].join('\n'))
+      'A --> B',
+    ])
     expect(protocol.props[':config']).toBe('config')
     expect(protocol.props).not.toHaveProperty(':toolbar')
   })

--- a/test/markdownDiagramProtocol.test.ts
+++ b/test/markdownDiagramProtocol.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { parseMarkdown } from '@nuxtjs/mdc/runtime'
+import type { MDCElement } from '@nuxtjs/mdc'
+import { parse as parseYaml } from 'yaml'
+import { transformMarkdownDiagrams } from '../src/markdown-diagram-transform'
+
+async function parseProtocol(markdown: string) {
+  const parsed = await parseMarkdown(transformMarkdownDiagrams(markdown), {
+    highlight: false,
+  })
+  const component = parsed.body.children.find(
+    (node): node is MDCElement => node.type === 'element' && node.tag.toLowerCase() === 'mermaid',
+  )
+
+  expect(component).toBeDefined()
+
+  const props = (component?.props || {}) as Record<string, unknown>
+  const source = decodeURIComponent(String(props.code || ''))
+  const toolbar = props[':toolbar'] === undefined
+    ? undefined
+    : JSON.parse(String(props[':toolbar'])) as Record<string, unknown>
+
+  return { parsed, component, props, source, toolbar }
+}
+
+function parseDiagramFrontmatter(source: string) {
+  const match = source.replace(/\r\n/g, '\n').match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+  expect(match).not.toBeNull()
+
+  return {
+    data: parseYaml(match?.[1] || '') as Record<string, unknown>,
+    diagram: match?.[2] || '',
+  }
+}
+
+describe('Markdown Diagram Protocol', () => {
+  it('preserves normalized metadata semantics through the Nuxt Content MDC parser', async () => {
+    const markdown = [
+      '---',
+      'config:',
+      '  theme: neutral',
+      '  flowchart:',
+      '    curve: basis',
+      '---',
+      '# Diagram',
+      '',
+      '```mermaid {title="Inline Title" displayMode="compact" toolbar.fontSize="18px" config=\'{"theme":"forest"}\'}',
+      '---',
+      'title: YAML Title',
+      'displayMode: standard',
+      'toolbar:',
+      '  title: YAML Toolbar',
+      '  buttons:',
+      '    copy: false',
+      'config:',
+      '  flowchart:',
+      '    htmlLabels: false',
+      '---',
+      'graph TD',
+      '  A --> B',
+      '```',
+      '',
+    ].join('\n')
+
+    const protocol = await parseProtocol(markdown)
+    const diagram = parseDiagramFrontmatter(protocol.source)
+
+    expect(protocol.component?.tag).toBe('mermaid')
+    expect(protocol.props[':config']).toBe('config')
+    expect(protocol.parsed.data.config).toEqual({
+      theme: 'neutral',
+      flowchart: {
+        curve: 'basis',
+      },
+    })
+    expect(protocol.toolbar).toEqual({
+      title: 'YAML Toolbar',
+      fontSize: '18px',
+      buttons: {
+        copy: false,
+      },
+    })
+    expect(diagram.data).toEqual({
+      title: 'Inline Title',
+      displayMode: 'compact',
+      toolbar: {
+        title: 'YAML Toolbar',
+        fontSize: '18px',
+        buttons: {
+          copy: false,
+        },
+      },
+      config: {
+        theme: 'forest',
+        flowchart: {
+          htmlLabels: false,
+        },
+      },
+    })
+    expect(diagram.diagram).toBe([
+      'graph TD',
+      '  A --> B',
+    ].join('\n'))
+  })
+
+  it('preserves invalid Mermaid YAML Frontmatter as a local fallback', async () => {
+    const markdown = [
+      '```mermaid',
+      '---',
+      'title: [invalid',
+      '---',
+      'graph TD',
+      '  A --> B',
+      '```',
+      '',
+    ].join('\n')
+
+    const protocol = await parseProtocol(markdown)
+
+    expect(protocol.source).toBe([
+      '---',
+      'title: [invalid',
+      '---',
+      'graph TD',
+      '  A --> B',
+    ].join('\n'))
+    expect(protocol.props[':config']).toBe('config')
+    expect(protocol.props).not.toHaveProperty(':toolbar')
+  })
+})

--- a/test/transformMermaid.test.ts
+++ b/test/transformMermaid.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { parse as parseYaml } from 'yaml'
+import { parseMarkdown } from '@nuxtjs/mdc/runtime'
+import type { MDCElement } from '@nuxtjs/mdc'
 import { transformMarkdownDiagrams } from '../src/markdown-diagram-transform'
 
 describe('transformMarkdownDiagrams', () => {
@@ -13,11 +15,16 @@ describe('transformMarkdownDiagrams', () => {
     return readFileSync(url, 'utf-8')
   }
 
-  const extractJsonProp = (output: string, prop: string) => {
-    const escaped = prop.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const match = output.match(new RegExp(`${escaped}='([^']+)'`))
-    if (!match) return null
-    return JSON.parse(match[1] || '{}') as Record<string, unknown>
+  const extractToolbarProp = async (output: string) => {
+    const parsed = await parseMarkdown(output, { highlight: false })
+    const component = parsed.body.children.find(
+      (node): node is MDCElement => node.type === 'element' && node.tag.toLowerCase() === 'mermaid',
+    )
+    const toolbar = component?.props?.[':toolbar']
+
+    return typeof toolbar === 'string'
+      ? JSON.parse(toolbar) as Record<string, unknown>
+      : null
   }
 
   const extractDecodedCode = (output: string) => {
@@ -153,7 +160,7 @@ describe('transformMarkdownDiagrams', () => {
     expect(output).toContain('<Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
   })
 
-  it('extracts toolbar props from mermaid YAML frontmatter', () => {
+  it('extracts toolbar props from mermaid YAML frontmatter', async () => {
     const body = [
       '```mermaid',
       '---',
@@ -168,13 +175,13 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(extractJsonProp(output, ':toolbar')).toEqual({
+    expect(await extractToolbarProp(output)).toEqual({
       title: 'Mermaid 1',
       fontSize: '24px',
     })
   })
 
-  it('keeps fullscreenToolbarScale from YAML toolbar config', () => {
+  it('keeps fullscreenToolbarScale from YAML toolbar config', async () => {
     const body = [
       '```mermaid',
       '---',
@@ -189,13 +196,13 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(extractJsonProp(output, ':toolbar')).toEqual({
+    expect(await extractToolbarProp(output)).toEqual({
       title: 'Mermaid 2',
       fullscreenToolbarScale: 1.5,
     })
   })
 
-  it('falls back to raw code when mermaid YAML frontmatter is invalid', () => {
+  it('falls back to raw code when mermaid YAML frontmatter is invalid', async () => {
     const body = [
       '```mermaid',
       '---',
@@ -217,10 +224,10 @@ describe('transformMarkdownDiagrams', () => {
       'graph TD',
       '  A --> B',
     ].join('\n'))
-    expect(output).not.toContain(':toolbar=')
+    expect(await extractToolbarProp(output)).toBeNull()
   })
 
-  it('does not map YAML title to toolbar title', () => {
+  it('does not map YAML title to toolbar title', async () => {
     const body = [
       '```mermaid',
       '---',
@@ -236,10 +243,10 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(output).not.toContain(':toolbar=')
+    expect(await extractToolbarProp(output)).toBeNull()
   })
 
-  it('ignores unsafe inline attrs like __proto__ in toolbar overrides', () => {
+  it('ignores unsafe inline attrs like __proto__ in toolbar overrides', async () => {
     const body = [
       '```mermaid {toolbar.__proto__="polluted" toolbar.title="Safe Title"}',
       'graph TD',
@@ -249,13 +256,13 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(extractJsonProp(output, ':toolbar')).toEqual({
+    expect(await extractToolbarProp(output)).toEqual({
       title: 'Safe Title',
     })
     expect(({} as { polluted?: unknown }).polluted).toBeUndefined()
   })
 
-  it('preserves numeric string fontSize in toolbar overrides', () => {
+  it('preserves numeric string fontSize in toolbar overrides', async () => {
     const body = [
       '```mermaid {toolbar.fontSize="16"}',
       'graph TD',
@@ -265,12 +272,12 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(extractJsonProp(output, ':toolbar')).toEqual({
+    expect(await extractToolbarProp(output)).toEqual({
       fontSize: '16',
     })
   })
 
-  it('merges YAML and inline props before passing to Mermaid', () => {
+  it('merges YAML and inline props before passing to Mermaid', async () => {
     const body = [
       '```mermaid {title="Inline Title" displayMode="compact" toolbar.fontSize="24px" config=\'{"theme":"forest","flowchart":{"curve":"step"}}\'}',
       '---',
@@ -291,7 +298,7 @@ describe('transformMarkdownDiagrams', () => {
 
     const output = transformMarkdownDiagrams(body)
 
-    expect(extractJsonProp(output, ':toolbar')).toEqual({
+    expect(await extractToolbarProp(output)).toEqual({
       title: 'YAML Toolbar',
       fontSize: '24px',
     })
@@ -314,7 +321,7 @@ describe('transformMarkdownDiagrams', () => {
     })
   })
 
-  it('preserves metadata precedence while filtering unsafe inline paths', () => {
+  it('preserves metadata precedence while filtering unsafe inline paths', async () => {
     const body = [
       '```mermaid {title="Inline Title" displayMode="compact" toolbar.fontSize="18px" toolbar.constructor.polluted=true config=\'{"theme":"forest"}\'}',
       '---',
@@ -336,7 +343,7 @@ describe('transformMarkdownDiagrams', () => {
 
     const output = transformMarkdownDiagrams(body)
 
-    expect(extractJsonProp(output, ':toolbar')).toEqual({
+    expect(await extractToolbarProp(output)).toEqual({
       title: 'YAML Toolbar',
       fontSize: '18px',
       buttons: {

--- a/test/transformMermaid.test.ts
+++ b/test/transformMermaid.test.ts
@@ -314,6 +314,54 @@ describe('transformMarkdownDiagrams', () => {
     })
   })
 
+  it('preserves metadata precedence while filtering unsafe inline paths', () => {
+    const body = [
+      '```mermaid {title="Inline Title" displayMode="compact" toolbar.fontSize="18px" toolbar.constructor.polluted=true config=\'{"theme":"forest"}\'}',
+      '---',
+      'title: YAML Title',
+      'displayMode: standard',
+      'toolbar:',
+      '  title: YAML Toolbar',
+      '  buttons:',
+      '    copy: false',
+      'config:',
+      '  flowchart:',
+      '    htmlLabels: false',
+      '---',
+      'graph TD',
+      '  A --> B',
+      '```',
+      '',
+    ].join('\n')
+
+    const output = transformMarkdownDiagrams(body)
+
+    expect(extractJsonProp(output, ':toolbar')).toEqual({
+      title: 'YAML Toolbar',
+      fontSize: '18px',
+      buttons: {
+        copy: false,
+      },
+    })
+    expect(extractFrontmatter(extractDecodedCode(output))).toEqual({
+      title: 'Inline Title',
+      displayMode: 'compact',
+      toolbar: {
+        title: 'YAML Toolbar',
+        fontSize: '18px',
+        buttons: {
+          copy: false,
+        },
+      },
+      config: {
+        theme: 'forest',
+        flowchart: {
+          htmlLabels: false,
+        },
+      },
+    })
+  })
+
   it('moves frontmatter above mermaid directives before rendering', () => {
     const body = [
       '```mermaid {title="Mermaid 2" toolbar=\'{"title":"Inline","fontSize":"16px"}\' config=\'{"theme":"dark"}\'}',


### PR DESCRIPTION
## Summary

- move Mermaid YAML Frontmatter and Mermaid Inline Attributes parsing, precedence, toolbar projection, unsafe-key filtering, and Selective Fallback into the internal Markdown Diagram Transform
- remove Markdown transformation helpers and transform-only serialization from the runtime utilities barrel
- verify the Markdown Diagram Protocol with the real Nuxt Content MDC parser while keeping Page Mermaid Config independent

## Acceptance coverage

- preserves established YAML/inline precedence, nested config and toolbar merging, unsafe path filtering, and unexpected-failure propagation
- normalizes and asserts Mermaid component identity, decoded diagram source, `:config="config"`, page `config` data, toolbar props, and invalid-frontmatter fallback
- avoids complete-markup snapshots and normalizes quote, newline, whitespace, key-order, and equivalent-encoding details
- leaves `src/module.ts`, Built-in Renderer, Custom Renderer, and the package-root `transformMermaidCodeBlocks` export unchanged

## Issue #10 parallel boundary

Issue #10 owns Nuxt Content adapter contraction. This PR does not modify `src/module.ts` or any other session branch/worktree. The only import relocation is inside the stable internal entry `src/markdown-diagram-transform.ts`.

## Tests

- `pnpm install --frozen-lockfile` — pass
- `pnpm lint --fix` — pass
- `pnpm exec vitest run test/transformMermaid.test.ts test/markdownDiagramProtocol.test.ts` — 24/24 pass
- `pnpm test:types` — pass for root and playground
- `pnpm test` — final fresh run 77/77 pass; an earlier parallel run had one transient custom-spinner visibility race (76/77)
- `pnpm exec vitest run --exclude '.agents/**' --no-file-parallelism` — 77/77 pass after the transient parallel failure
- `pnpm prepack` — pass

## Review

- Standards axis: no hard violations; clarified the transform-only serializer name
- Spec axis: normalized toolbar and fallback assertions through MDC parsing so tests do not constrain quote or whitespace spelling

Closes #9
