### PR TITLE
refactor: remove legacy transform export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.0.0 (unreleased)
+
+### 💅 Refactors
+
+- Remove the undocumented package-root `transformMermaidCodeBlocks` runtime and TypeScript exports.
+
+#### ⚠️ Breaking Changes
+
+- 3.0.0 removes the undocumented package-root `transformMermaidCodeBlocks` export. There is no replacement API; Package Users should continue to install the Nuxt module through its default export. This is Candidate 02's only intentionally accepted breaking change.
+
 ## v2.2.3
 
 [compare changes](https://github.com/andy820621/nuxt-content-mermaid/compare/v2.2.2...v2.2.3)

--- a/docs/superpowers/specs/2026-08-02-remove-legacy-transform-export-implementation.md
+++ b/docs/superpowers/specs/2026-08-02-remove-legacy-transform-export-implementation.md
@@ -1,0 +1,67 @@
+# Remove Legacy Transform Export Implementation Notes
+
+## Scope
+
+Issue #11 completes the Candidate 02 package-contract contraction designed in
+Issue #7. The package root no longer exposes `transformMermaidCodeBlocks` at
+runtime or through generated TypeScript declarations. No alias, deprecated
+wrapper, or replacement API is provided.
+
+`src/markdown-diagram-transform.ts` remains a module/build-time internal seam.
+It is not exported from the package root, the runtime utilities barrel, or the
+app runtime.
+
+## Preserved package contract
+
+The package root continues to provide the Nuxt module default export and the
+intentionally supported `ModuleOptions` type. Loading the package declarations
+also preserves the existing `NuxtConfig.contentMermaid` augmentation.
+
+The Nuxt Content adapter remains unchanged: it checks `.md` eligibility,
+passes the complete body to `transformMarkdownDiagrams(body)`, and writes the
+exact result back to `file.body`. The Markdown Diagram Protocol, Page Mermaid
+Config runtime channel, Built-in Renderer, Custom Renderer, SSR, and Package
+User rendering paths are unchanged.
+
+## Built-artifact verification
+
+`pnpm prepack` produces the package artifacts under the ignored `dist`
+directory. `test/packageContract.test.ts` imports the package self-reference,
+which resolves through `package.json` to the built runtime, and verifies the
+module namespace has a default export but no `transformMermaidCodeBlocks` key.
+The test does not inspect source text or snapshot bundle formatting.
+
+`test/package-contract/package-user.ts` and `removed-transform.ts` are compiled
+through their focused Package User `tsconfig.json`. The positive fixture
+verifies the default export, `ModuleOptions`, and the Nuxt config augmentation
+against `dist/types.d.mts`. The negative fixture's `@ts-expect-error` applies
+only to the removed legacy named type import. On the Issue #11 base, the
+directive is unused because the generated declarations still expose that name;
+after the contraction it is consumed by the missing export error. The separate
+positive fixture prevents a package-resolution error from making the negative
+assertion pass accidentally.
+
+Neither check depends on declaration whitespace, export order, diagnostic
+wording, diagnostic codes, line numbers, or a full artifact snapshot.
+
+## Release and regression coverage
+
+The 3.0.0 changelog identifies removal of the undocumented package-root export,
+states that no replacement API exists, and records it as Candidate 02's only
+intentionally accepted breaking change.
+
+The existing Nuxt E2E suite remains the regression gate:
+
+- `test/basic.test.ts` covers SSR for a Nuxt fixture with the module enabled.
+- `test/builtInRenderer.e2e.test.ts` covers the Package User Nuxt rendering
+  path through the Built-in Renderer.
+- `test/customRenderer.e2e.test.ts` and
+  `test/customComponents.e2e.test.ts` cover Custom Renderer paths.
+
+## Explicitly out of scope
+
+This change does not modify the Nuxt Content hook, Markdown fence grammar,
+scanner, metadata parsing or precedence, toolbar semantics, unsafe-key
+filtering, Selective Fallback, unexpected failure propagation, renderer code,
+diagnostics, dependencies, performance, version metadata, tags, publishing, or
+release automation.

--- a/src/module.ts
+++ b/src/module.ts
@@ -272,11 +272,3 @@ export {}
     })
   },
 })
-
-export function transformMermaidCodeBlocks(
-  body: string,
-  _componentName: string,
-  _frontmatterConfigKey?: string,
-) {
-  return transformMarkdownDiagrams(body)
-}

--- a/test/package-contract/package-user.ts
+++ b/test/package-contract/package-user.ts
@@ -1,0 +1,18 @@
+import contentMermaidModule, { type ModuleOptions } from '@barzhsieh/nuxt-content-mermaid'
+import type { NuxtConfig, NuxtModule } from '@nuxt/schema'
+
+const options = {
+  enabled: true,
+  toolbar: {
+    title: 'Diagram',
+    buttons: {
+      copy: true,
+    },
+  },
+} satisfies ModuleOptions
+
+const moduleDefinition: NuxtModule<ModuleOptions> = contentMermaidModule
+const nuxtConfig: NuxtConfig = { contentMermaid: options }
+
+void moduleDefinition
+void nuxtConfig

--- a/test/package-contract/removed-transform.ts
+++ b/test/package-contract/removed-transform.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error 3.0.0 intentionally removes this legacy package-root export.
+import type { transformMermaidCodeBlocks as _LegacyTransform } from '@barzhsieh/nuxt-content-mermaid'

--- a/test/package-contract/tsconfig.json
+++ b/test/package-contract/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "./package-user.ts",
+    "./removed-transform.ts"
+  ]
+}

--- a/test/packageContract.test.ts
+++ b/test/packageContract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+describe('package root runtime contract', () => {
+  it('exposes the Nuxt module without the legacy package-root transform export', async () => {
+    const packageModule = await import('@barzhsieh/nuxt-content-mermaid')
+
+    expect(packageModule.default).toBeDefined()
+    expect('transformMermaidCodeBlocks' in packageModule).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Remove the undocumented `transformMermaidCodeBlocks` named export from the package-root runtime and generated TypeScript declarations.
- Preserve the default Nuxt module export, the supported `ModuleOptions` type, and the `NuxtConfig.contentMermaid` augmentation.
- Document that this is Candidate 02 / 3.0.0's only intentional breaking change and that there is no replacement API.

## Acceptance coverage

### Runtime package contract

- Added a package self-reference Vitest assertion against a freshly built `dist` artifact.
- The runtime namespace still exposes the default Nuxt module export.
- The runtime namespace no longer contains `transformMermaidCodeBlocks`.
- The test checks observable namespace membership and does not snapshot bundle text, formatting, or export order.

### TypeScript package contract

- Added a focused Package User typecheck against the freshly generated package declarations.
- The negative assertion proves the legacy package-root named import is rejected; on the original base it reliably failed with an unused `@ts-expect-error` because the generated declaration still exposed the name.
- Separate positive assertions prove the default Nuxt module export, `ModuleOptions`, and `NuxtConfig.contentMermaid` remain usable.
- The checks do not depend on exact TypeScript diagnostic text, code, line number, declaration whitespace, or export order.

### Release contract

- Added an unreleased 3.0.0 changelog entry stating that the undocumented package-root export is removed, there is no replacement API, and this is Candidate 02's only intentional breaking change.
- Added an Issue #11 implementation note covering the removed and preserved surfaces, fresh-artifact verification, E2E coverage, semantic compatibility, and explicit out-of-scope work.

## Preserved behavior and E2E coverage

- `basic.test.ts`: Nuxt SSR fixture with the module enabled.
- `builtInRenderer.e2e.test.ts`: Package User Nuxt rendering path through the Built-in Renderer.
- `customRenderer.e2e.test.ts` and `customComponents.e2e.test.ts`: Custom Renderer paths.
- The Nuxt Content adapter, Markdown Diagram Protocol, Page Mermaid Config channel, Built-in Renderer, Custom Renderer, SSR, and Package User rendering semantics are unchanged.

## Validation

- `pnpm install --frozen-lockfile` — passed.
- `pnpm dev:prepare` — passed; generated the ignored Nuxt preparation state required by a fresh worktree.
- `pnpm lint --fix` — passed.
- `pnpm exec vitest run test/packageContract.test.ts --no-file-parallelism` — passed (1 file, 1 test).
- `pnpm exec vue-tsc --noEmit --project test/package-contract/tsconfig.json` — passed.
- `pnpm test:types` — passed.
- `pnpm test` — passed (16 files, 81 tests).
- `pnpm prepack` — passed; fresh production output reports only the default runtime export.
- Focused Nuxt E2E gate covering basic SSR, Built-in Renderer, Custom Renderer, and Package User paths — passed (5 files, 9 tests).
- Fresh `dist` runtime and type package-contract checks were rerun after the final review fixes and passed.

## Code review

- Standards axis: two terminology findings were fixed; final review has no findings.
- Spec axis: one E2E documentation overclaim was corrected; final review has no findings.
- Review fixed point: `6cedf7de4768f986c255e9afd4e27a4a59b051c3` (`origin/main`).

## Out of scope and parallel boundaries

- No replacement transform, alias, deprecated wrapper, parser, callback, hook, plugin point, or extension interface was added.
- `src/markdown-diagram-transform.ts` remains an internal seam and was not exported from the package root, runtime utilities, or app runtime.
- No adapter, grammar, scanner, serialization, metadata precedence, toolbar, safe-key, fallback, renderer, diagnostics, dependency, performance, version, tag, publish, or release work is included.
- This work was created from the latest `origin/main` in a fresh Issue #11 worktree and does not reuse, modify, or clean Issue #9 or Issue #10 branches/worktrees.
- Parent Issue #7 is not closed by this PR.

Closes #11
