### PR TITLE
refactor: deepen expand lifecycle ownership

### DIFF
--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -19,7 +19,6 @@ import { mergeMermaidConfig, resolveMermaidTheme } from '../mermaid-config'
 import { createMermaidRenderer } from '../mermaid-rendering'
 import { parseSizeToPx, isRecord } from '../utils'
 import { useMermaidTheme } from '../composables/useMermaidTheme'
-import { useMermaidExpand } from '../composables/useMermaidExpand'
 import { useMermaidCursors } from '../composables/useMermaidCursors'
 import { useFullscreen } from '../composables/useFullscreen'
 import { useMermaidZoom } from '../composables/useMermaidZoom'
@@ -72,16 +71,7 @@ function resolveExpandOptions(expand: ModuleOptions['expand']): ExpandOptions {
 const expandOptions = resolveExpandOptions(contentMermaidOptions.expand)
 const expandEnabled = expandOptions.enabled !== false
 const expandOpenOptions = expandOptions.invokeOpenOn || {}
-const expandCloseOptions = expandOptions.invokeCloseOn || {}
-const expandMargin = typeof expandOptions.margin === 'number' && Number.isFinite(expandOptions.margin)
-  ? Math.max(0, expandOptions.margin)
-  : 0
 const allowOpenDiagramClick = expandOpenOptions.diagramClick !== false
-const allowOverlayClose = expandCloseOptions.overlayClick !== false
-const allowCloseButtonClose = expandCloseOptions.closeButtonClick !== false
-const allowEscClose = expandCloseOptions.esc !== false
-const allowWheelClose = expandCloseOptions.wheel !== false
-const allowSwipeClose = expandCloseOptions.swipe !== false
 
 const lazyOption = loaderOptions.lazy
 const isLazy = lazyOption !== false
@@ -382,31 +372,19 @@ if (import.meta.client) {
   })
 }
 
-const {
-  setExpandTargetWrap,
-  expandTargetStyle,
-  isExpandActive,
-  isVisible,
-  closeExpand,
-  toggleExpand,
-  handleExpandTransitionEnd,
-  handleMermaidClick,
-  resetExpand,
-  zoom,
-  showZoomHint,
-} = useMermaidExpand({
-  getExpandTarget: getMermaidSvg,
-  expandMargin,
-  isBlocked: isExpandBlocked,
-  invokeOpenOn: {
-    diagramClick: allowOpenDiagramClick,
-  },
-  invokeCloseOn: {
-    esc: allowEscClose,
-    wheel: allowWheelClose,
-    swipe: allowSwipeClose,
-  },
-})
+interface MermaidExpandOverlayExpose {
+  toggle: (event?: Event) => void
+  openFromDiagram: (event: MouseEvent) => void
+  endForDiagramReplacement: () => void
+}
+
+const expandOverlay = useTemplateRef<MermaidExpandOverlayExpose>('expandOverlay')
+const isExpandActive = ref(false)
+const handleExpandActiveChange = (active: boolean) => {
+  isExpandActive.value = active
+}
+const toggleExpand = (event?: Event) => expandOverlay.value?.toggle(event)
+const handleMermaidClick = (event: MouseEvent) => expandOverlay.value?.openFromDiagram(event)
 
 let requestBuiltInRender: ReturnType<typeof createMermaidRenderer> | undefined
 
@@ -419,8 +397,8 @@ function getBuiltInRenderRequest() {
       target: mermaidContainer.value,
     }),
     prepare: () => {
-      if (import.meta.client && isExpandActive.value)
-        resetExpand()
+      if (import.meta.client)
+        expandOverlay.value?.endForDiagramReplacement()
 
       hasError.value = false
       errorContent.value = null
@@ -894,20 +872,14 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
       </div>
 
       <MermaidExpandOverlay
-        :active="isExpandActive"
-        :is-visable="isVisible"
+        ref="expandOverlay"
+        :options="expandOptions"
+        :blocked="isExpandBlocked"
+        :get-expand-target="getMermaidSvg"
         :overlay-style="cursorVariables"
         :content-style="cursorVariables"
-        :target-style="expandTargetStyle"
-        :target-ref="setExpandTargetWrap"
-        :allow-overlay-close="allowOverlayClose"
-        :allow-close-button="allowCloseButtonClose"
-        :target-has-margin="expandMargin > 0"
         :icon-size="iconSize"
-        :zoom="zoom"
-        :show-hint="showZoomHint"
-        @close="closeExpand"
-        @transitionend="handleExpandTransitionEnd"
+        @active-change="handleExpandActiveChange"
       />
     </div>
   </div>

--- a/src/runtime/components/MermaidExpandOverlay.vue
+++ b/src/runtime/components/MermaidExpandOverlay.vue
@@ -1,77 +1,75 @@
 <script setup lang="ts">
-import type { CSSProperties, ComponentPublicInstance } from 'vue'
-import type { MermaidZoomReturn } from '../composables/useMermaidZoom'
+import { computed, watch } from 'vue'
+import type { CSSProperties } from 'vue'
+import type { ExpandOptions } from '../types/expand'
+import { useMermaidExpand } from '../composables/useMermaidExpand'
 import MermaidZoomToolbar from './MermaidZoomToolbar.vue'
 
 const props = defineProps<{
-  active: boolean
-  isVisable: boolean
+  options: ExpandOptions
+  blocked: boolean
+  getExpandTarget: () => SVGElement | null
   overlayStyle?: CSSProperties
   contentStyle?: CSSProperties
-  targetStyle?: CSSProperties
-  targetRef: (el: Element | ComponentPublicInstance | null) => void
-  allowOverlayClose: boolean
-  allowCloseButton: boolean
-  targetHasMargin: boolean
   iconSize?: number
-  zoom?: MermaidZoomReturn
-  showHint?: boolean
 }>()
 
 const isMac = import.meta.client ? /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) : false
 
 const emit = defineEmits<{
-  (e: 'close', event?: Event): void
-  (e: 'transitionend', event: TransitionEvent): void
+  (e: 'active-change', active: boolean): void
 }>()
 
-const handleButtonClick = (event: MouseEvent) => {
-  if (!props.allowCloseButton) return
-  emit('close', event)
-}
+const blocked = computed(() => props.blocked)
+const allowCloseButton = computed(() => props.options.invokeCloseOn?.closeButtonClick !== false)
+const targetHasMargin = computed(() => typeof props.options.margin === 'number' && props.options.margin > 0)
 
-// Handler for Modal Click (captures everything)
-const handleModalClick = (event: MouseEvent) => {
-  // Check explicit drag flag
-  if (props.zoom?.isSpacePressed.value) return
-  if (props.zoom?.wasLastInteractionDrag.value) {
-    event.stopPropagation()
-    return
-  }
+const {
+  setExpandModal,
+  setExpandTargetWrap,
+  expandTargetStyle,
+  isExpandActive,
+  isVisible,
+  toggle,
+  openFromDiagram,
+  endForDiagramReplacement,
+  closeFromButton,
+  zoomIn,
+  zoomOut,
+  resetZoom,
+  cursor,
+  isDragging,
+  scale,
+  isOverlayClosable,
+  showZoomHint,
+} = useMermaidExpand({
+  getExpandTarget: props.getExpandTarget,
+  expandOptions: props.options,
+  isBlocked: blocked,
+})
 
-  // If it wasn't a drag, check where we clicked.
-  // If we clicked on the overlay element (background), try to close.
-  const target = event.target as HTMLElement
-  if (target.classList.contains('ncm-expand-overlay') || target.classList.contains('ncm-expand-modal')) {
-    if (props.allowOverlayClose) {
-      emit('close', event)
-    }
-  }
-}
+watch(isExpandActive, active => emit('active-change', active), { flush: 'sync', immediate: true })
+
+defineExpose({ toggle, openFromDiagram, endForDiagramReplacement })
 </script>
 
 <template>
   <Teleport to="body">
     <div
-      v-if="active"
+      v-if="isExpandActive"
+      :ref="setExpandModal"
       class="ncm-expand-modal"
       :style="{
-        cursor: zoom?.cursor.value || 'auto',
+        cursor,
       }"
-      @click="handleModalClick"
-      @mousedown="zoom?.handleDragStart($event)"
-      @mousemove="zoom?.handleDragMove($event)"
-      @touchstart="zoom?.handleDragStart($event)"
-      @touchmove="zoom?.handleDragMove($event)"
-      @touchend="zoom?.handleDragEnd()"
     >
       <div
         class="ncm-expand-overlay"
         :style="overlayStyle"
         :class="{
-          'ncm-expand-overlay-visible': isVisable,
-          'ncm-expand-overlay-closable': allowOverlayClose && !zoom?.isSpacePressed.value,
-          'ncm-expand-dragging': zoom?.isDragging.value,
+          'ncm-expand-overlay-visible': isVisible,
+          'ncm-expand-overlay-closable': isOverlayClosable,
+          'ncm-expand-dragging': isDragging,
         }"
       />
       <div
@@ -79,30 +77,28 @@ const handleModalClick = (event: MouseEvent) => {
         :style="contentStyle"
       >
         <div
-          :ref="targetRef"
+          :ref="setExpandTargetWrap"
           class="ncm-expand-target"
           :class="{
             'ncm-expand-target-with-margin': targetHasMargin,
           }"
-          :style="targetStyle"
-          @transitionend="emit('transitionend', $event)"
+          :style="expandTargetStyle"
         />
 
         <!-- Zoom Toolbar -->
         <MermaidZoomToolbar
-          v-if="zoom"
-          :scale="zoom.scale.value"
+          :scale="scale"
           :icon-size="iconSize"
           :icon-scale="0.75"
-          @zoom-out="zoom.zoomOut()"
-          @zoom-in="zoom.zoomIn()"
-          @reset="zoom.reset()"
+          @zoom-out="zoomOut"
+          @zoom-in="zoomIn"
+          @reset="resetZoom"
         />
 
         <!-- Zoom Hint Toast -->
         <Transition name="ncm-hint-fade">
           <div
-            v-if="showHint"
+            v-if="showZoomHint"
             class="ncm-zoom-hint"
           >
             {{ isMac ? '⌘' : 'Ctrl' }} + Scroll to zoom
@@ -114,7 +110,7 @@ const handleModalClick = (event: MouseEvent) => {
           type="button"
           class="ncm-expand-btn"
           aria-label="Minimize diagram"
-          @click="handleButtonClick"
+          @click="closeFromButton"
           @mousedown.stop
           @touchstart.stop
         >

--- a/src/runtime/composables/useMermaidExpand.ts
+++ b/src/runtime/composables/useMermaidExpand.ts
@@ -1,6 +1,6 @@
 import { computed, nextTick, ref } from 'vue'
 import type { CSSProperties, ComponentPublicInstance, Ref } from 'vue'
-import type { ExpandInvokeCloseOn, ExpandInvokeOpenOn } from '../types/expand'
+import type { ExpandOptions } from '../types/expand'
 import { useMermaidZoom } from './useMermaidZoom'
 import { useEventListener } from './useEventListener'
 import { tryOnScopeDispose } from './shared/tryOnScopeDispose'
@@ -19,10 +19,8 @@ interface ExpandMetrics {
 
 interface UseMermaidExpandOptions {
   getExpandTarget: () => SVGElement | null
-  expandMargin?: number
+  expandOptions: ExpandOptions
   isBlocked?: Ref<boolean>
-  invokeOpenOn?: ExpandInvokeOpenOn
-  invokeCloseOn?: ExpandInvokeCloseOn
 }
 
 const swipeToCloseThreshold = 10
@@ -32,6 +30,10 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     ? import.meta.client
     : typeof window !== 'undefined' && typeof document !== 'undefined'
   const expandTargetWrap = ref<HTMLDivElement | null>(null)
+  const expandModal = ref<HTMLDivElement | null>(null)
+  const setExpandModal = (el: Element | ComponentPublicInstance | null) => {
+    expandModal.value = el && 'nodeType' in el ? el as HTMLDivElement : null
+  }
   const setExpandTargetWrap = (el: Element | ComponentPublicInstance | null) => {
     if (el && 'nodeType' in el) {
       expandTargetWrap.value = el as HTMLDivElement
@@ -57,10 +59,12 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     maxScale: 10,
   })
   const isVisible = computed(() => expandState.value === 'open')
-  const allowTargetClick = options.invokeOpenOn?.diagramClick !== false
-  const allowCloseByEsc = options.invokeCloseOn?.esc !== false
-  const allowCloseByWheel = options.invokeCloseOn?.wheel !== false
-  const allowCloseBySwipe = options.invokeCloseOn?.swipe !== false
+  const allowTargetClick = options.expandOptions.invokeOpenOn?.diagramClick !== false
+  const allowCloseByEsc = options.expandOptions.invokeCloseOn?.esc !== false
+  const allowCloseByWheel = options.expandOptions.invokeCloseOn?.wheel !== false
+  const allowCloseBySwipe = options.expandOptions.invokeCloseOn?.swipe !== false
+  const allowOverlayClose = options.expandOptions.invokeCloseOn?.overlayClick !== false
+  const allowCloseButton = options.expandOptions.invokeCloseOn?.closeButtonClick !== false
 
   const expandTargetStyle = computed<CSSProperties>(() => {
     const metrics = expandMetrics.value
@@ -82,6 +86,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
 
   let expandTransitionTimeout: ReturnType<typeof setTimeout> | undefined
   let expandResizeTimeout: ReturnType<typeof setTimeout> | undefined
+  let openingRaf: number | undefined
 
   const resizeDoubleRaf = {
     raf1: undefined as number | undefined,
@@ -114,6 +119,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     htmlOverflow: '',
     htmlWidth: '',
     lockedWidth: false,
+    locked: false,
   }
   const touchState: { isScaling: boolean, start?: number, end?: number } = {
     isScaling: false,
@@ -121,7 +127,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
   let expandInstanceId = 0
 
   function resolveExpandMargin() {
-    const margin = options.expandMargin
+    const margin = options.expandOptions.margin
     if (typeof margin !== 'number' || Number.isNaN(margin)) return 0
     return Math.max(0, margin)
   }
@@ -164,6 +170,30 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
   function clearRefreshRaf() {
     if (expandRefreshRaf != null) cancelAnimationFrame(expandRefreshRaf)
     expandRefreshRaf = undefined
+  }
+
+  function clearOpeningRaf() {
+    if (openingRaf != null) cancelAnimationFrame(openingRaf)
+    openingRaf = undefined
+  }
+
+  function resetSwipeState() {
+    touchState.isScaling = false
+    touchState.start = undefined
+    touchState.end = undefined
+  }
+
+  function cancelPendingWork() {
+    clearTimeout(expandTransitionTimeout)
+    clearTimeout(hintTimeout)
+    expandTransitionTimeout = undefined
+    hintTimeout = undefined
+    clearResizeTimers()
+    clearRefreshRaf()
+    clearOpeningRaf()
+    showZoomHint.value = false
+    resetSwipeState()
+    zoom.cancelInteraction()
   }
 
   function calculateExpandMetrics(target: SVGElement): ExpandMetrics | null {
@@ -264,10 +294,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
 
   function resetExpand() {
     if (!isClient) return
-    clearTimeout(expandTransitionTimeout)
-    clearTimeout(hintTimeout)
-    clearResizeTimers()
-    clearRefreshRaf()
+    cancelPendingWork()
     clearExpandSvg()
     expandState.value = 'idle'
     isExpanded.value = false
@@ -310,7 +337,8 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
         return
       }
 
-      requestAnimationFrame(() => {
+      openingRaf = requestAnimationFrame(() => {
+        openingRaf = undefined
         if (expandState.value !== 'opening') return
         isExpanded.value = true
         expandState.value = 'open'
@@ -324,6 +352,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
       resetExpand()
       return
     }
+    cancelPendingWork()
     expandState.value = 'closing'
     isExpanded.value = false
     ensureExpandTransitionEnd()
@@ -478,16 +507,12 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
 
   function handleExpandTouchEnd() {
     if (!allowCloseBySwipe) return
-    touchState.isScaling = false
-    touchState.start = undefined
-    touchState.end = undefined
+    resetSwipeState()
   }
 
   function handleExpandTouchCancel() {
     if (!allowCloseBySwipe) return
-    touchState.isScaling = false
-    touchState.start = undefined
-    touchState.end = undefined
+    resetSwipeState()
   }
 
   function handleExpandResize() {
@@ -537,6 +562,8 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     const activeWindow = computed(() => isExpandActive.value ? window : null)
     const activeDocument = computed(() => isExpandActive.value ? document : null)
     const activeVisualViewport = computed(() => (isExpandActive.value ? window.visualViewport : null))
+    const activeModal = computed(() => isExpandActive.value ? expandModal.value : null)
+    const activeTarget = computed(() => isExpandActive.value ? expandTargetWrap.value : null)
 
     useEventListener(activeWindow, 'resize', handleExpandResize, { passive: true })
     useEventListener(activeWindow, 'orientationchange', handleExpandResize, { passive: true })
@@ -547,14 +574,23 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     useEventListener(activeWindow, 'touchend', handleExpandTouchEnd, { passive: true })
     useEventListener(activeWindow, 'touchcancel', handleExpandTouchCancel, { passive: true })
     useEventListener(activeDocument, 'keydown', handleExpandKeyDown, true)
+    useEventListener(activeModal, 'click', handleModalClick)
+    useEventListener(activeModal, 'mousedown', zoom.handleDragStart)
+    useEventListener(activeModal, 'mousemove', zoom.handleDragMove)
+    useEventListener(activeModal, 'touchstart', zoom.handleDragStart)
+    useEventListener(activeModal, 'touchmove', zoom.handleDragMove)
+    useEventListener(activeModal, 'touchend', zoom.handleDragEnd)
+    useEventListener(activeTarget, 'transitionend', handleExpandTransitionEnd)
   }
 
   function disableBodyScroll() {
+    if (scrollState.locked) return
     scrollState.bodyOverflow = document.body.style.overflow
     scrollState.bodyWidth = document.body.style.width
     scrollState.htmlOverflow = document.documentElement.style.overflow
     scrollState.htmlWidth = document.documentElement.style.width
     scrollState.lockedWidth = shouldLockWidth()
+    scrollState.locked = true
     document.documentElement.style.overflow = 'hidden'
     document.body.style.overflow = 'hidden'
     if (scrollState.lockedWidth) {
@@ -565,6 +601,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
   }
 
   function enableBodyScroll() {
+    if (!scrollState.locked) return
     document.documentElement.style.width = scrollState.htmlWidth
     document.documentElement.style.overflow = scrollState.htmlOverflow
     scrollState.htmlOverflow = ''
@@ -574,6 +611,7 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     scrollState.bodyOverflow = ''
     scrollState.bodyWidth = ''
     scrollState.lockedWidth = false
+    scrollState.locked = false
   }
 
   function handleMermaidClick(event: MouseEvent) {
@@ -585,22 +623,48 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     openExpand(event)
   }
 
+  function handleModalClick(event: MouseEvent) {
+    if (zoom.isSpacePressed.value) return
+    if (zoom.wasLastInteractionDrag.value) {
+      event.stopPropagation()
+      return
+    }
+
+    const target = event.target as HTMLElement
+    if (!target.classList?.contains('ncm-expand-overlay') && !target.classList?.contains('ncm-expand-modal')) return
+    if (allowOverlayClose) closeExpand(event)
+  }
+
+  function closeFromButton(event?: Event) {
+    if (allowCloseButton) closeExpand(event)
+  }
+
+  function endForDiagramReplacement() {
+    if (isExpandActive.value) resetExpand()
+  }
+
   tryOnScopeDispose(() => {
     if (isClient) resetExpand()
   })
 
   return {
+    setExpandModal,
     setExpandTargetWrap,
     expandTargetStyle,
     isExpandActive,
     isVisible,
-    openExpand,
-    closeExpand,
-    toggleExpand,
-    handleExpandTransitionEnd,
-    handleMermaidClick,
-    resetExpand,
-    zoom,
+    toggle: toggleExpand,
+    openFromDiagram: handleMermaidClick,
+    endForDiagramReplacement,
+    closeFromButton,
+    zoomIn: zoom.zoomIn,
+    zoomOut: zoom.zoomOut,
+    resetZoom: zoom.reset,
+    cursor: computed(() => zoom.cursor.value),
+    isDragging: computed(() => zoom.isDragging.value),
+    isSpacePressed: computed(() => zoom.isSpacePressed.value),
+    scale: computed(() => zoom.scale.value),
+    isOverlayClosable: computed(() => allowOverlayClose && !zoom.isSpacePressed.value),
     showZoomHint,
   }
 }

--- a/src/runtime/composables/useMermaidExpand.ts
+++ b/src/runtime/composables/useMermaidExpand.ts
@@ -662,7 +662,6 @@ export function useMermaidExpand(options: UseMermaidExpandOptions) {
     resetZoom: zoom.reset,
     cursor: computed(() => zoom.cursor.value),
     isDragging: computed(() => zoom.isDragging.value),
-    isSpacePressed: computed(() => zoom.isSpacePressed.value),
     scale: computed(() => zoom.scale.value),
     isOverlayClosable: computed(() => allowOverlayClose && !zoom.isSpacePressed.value),
     showZoomHint,

--- a/src/runtime/composables/useMermaidZoom.ts
+++ b/src/runtime/composables/useMermaidZoom.ts
@@ -17,6 +17,9 @@ export interface UseMermaidZoomOptions {
 }
 
 export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
+  const isClient = typeof import.meta.client === 'boolean'
+    ? import.meta.client
+    : typeof window !== 'undefined' && typeof document !== 'undefined'
   const {
     active = ref(true),
     minScale = 0.5,
@@ -39,6 +42,12 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   // Interaction tracking
   const wasLastInteractionDrag = ref(false)
   let totalMovement = 0
+  let startX = 0
+  let startY = 0
+  let lastX = 0
+  let lastY = 0
+  let lastPinchDist = -1
+  let wasPinching = false
 
   // Store initial state for reset
   const initialMetrics = ref<ZoomMetrics>({ scale: 1, translateX: 0, translateY: 0 })
@@ -59,7 +68,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   })
 
   function lockUserSelect() {
-    if (!import.meta.client) return
+    if (!isClient) return
     if (userSelectState.locked) return
     userSelectState.html = document.documentElement.style.userSelect
     userSelectState.body = document.body.style.userSelect
@@ -69,7 +78,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   }
 
   function unlockUserSelect() {
-    if (!import.meta.client) return
+    if (!isClient) return
     if (!userSelectState.locked) return
     document.documentElement.style.userSelect = userSelectState.html
     document.body.style.userSelect = userSelectState.body
@@ -82,12 +91,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     initialMetrics.value = { ...metrics }
     origin.value = { x: metrics.left || 0, y: metrics.top || 0 }
     // Reset states
-    isDragging.value = false
-    isPointerDown.value = false
-    isSpacePressed.value = false
-    wasLastInteractionDrag.value = false
-    totalMovement = 0
-    unlockUserSelect()
+    cancelInteraction()
     setMetrics(metrics)
   }
 
@@ -143,18 +147,27 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     handleDragEnd()
   }
 
+  function cancelInteraction() {
+    isDragging.value = false
+    isPointerDown.value = false
+    isSpacePressed.value = false
+    wasLastInteractionDrag.value = false
+    totalMovement = 0
+    lastPinchDist = -1
+    wasPinching = false
+    unlockUserSelect()
+  }
+
   // --- Global Listeners (Managed) ---
 
-  if (import.meta.client) {
+  if (isClient) {
     // Elegant toggle: When active is false, target becomes null, listener is removed.
     const activeDocument = computed(() => active.value ? document : null)
     const activeWindow = computed(() => active.value ? window : null)
 
     watch(active, (isActive) => {
       if (isActive) return
-      isSpacePressed.value = false
-      unlockUserSelect()
-      endInteraction()
+      cancelInteraction()
     })
 
     useEventListener(activeDocument, 'keydown', (e: KeyboardEvent) => {
@@ -213,13 +226,6 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   }
 
   // Drag State
-  let startX = 0
-  let startY = 0
-  let lastX = 0
-  let lastY = 0
-  let lastPinchDist = -1
-  let wasPinching = false
-
   function getDistance(t1: Touch, t2: Touch) {
     const dx = t1.clientX - t2.clientX
     const dy = t1.clientY - t2.clientY
@@ -356,6 +362,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     handleDragStart,
     handleDragMove,
     handleDragEnd,
+    cancelInteraction,
     isPointerDown,
   }
 }

--- a/test/builtInRenderer.e2e.test.ts
+++ b/test/builtInRenderer.e2e.test.ts
@@ -144,9 +144,34 @@ describe('built-in renderer integration', async () => {
     await page.locator('#primary [aria-label="Expand diagram"]').click()
     await page.locator('.ncm-expand-modal').waitFor({ state: 'visible', timeout: 5000 })
 
+    const activeInteraction = await page.evaluate(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true }))
+      const modal = document.querySelector('.ncm-expand-modal')
+      modal?.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true, cancelable: true }))
+      const target = document.querySelector('.ncm-expand-target')
+      target?.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }))
+      return document.body.style.userSelect
+    })
+    expect(activeInteraction).toBe('none')
+    await page.locator('.ncm-zoom-hint').waitFor({ state: 'visible', timeout: 2000 })
+
     await releaseNext(page)
     await waitForRuns(page, 5)
     await page.locator('.ncm-expand-modal').waitFor({ state: 'detached', timeout: 5000 })
+    expect(await page.locator('.ncm-zoom-hint, .ncm-expand-target svg').count()).toBe(0)
+    expect(await page.evaluate(() => {
+      const wheel = new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true })
+      const key = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      window.dispatchEvent(wheel)
+      document.dispatchEvent(key)
+      return {
+        wheel: wheel.defaultPrevented,
+        key: key.defaultPrevented,
+        overflow: document.body.style.overflow,
+        width: document.body.style.width,
+        userSelect: document.body.style.userSelect,
+      }
+    })).toEqual({ wheel: false, key: false, overflow: '', width: '', userSelect: '' })
     await releaseNext(page)
     await page.locator('#primary svg[data-run-id="5"]').waitFor({ state: 'visible', timeout: 5000 })
   })

--- a/test/expandToolbar.e2e.test.ts
+++ b/test/expandToolbar.e2e.test.ts
@@ -10,13 +10,71 @@ const parsePercent = (value: string | null) => {
   return Number.parseInt(value.replace('%', '').trim(), 10)
 }
 
+type BrowserPage = Awaited<ReturnType<typeof createPage>>
+
+const restoredPageStyles = {
+  bodyOverflow: '',
+  bodyWidth: '',
+  bodyUserSelect: '',
+  htmlOverflow: '',
+  htmlWidth: '',
+  htmlUserSelect: '',
+}
+
+async function readPageStyles(page: BrowserPage) {
+  return page.evaluate(() => ({
+    bodyOverflow: document.body.style.overflow,
+    bodyWidth: document.body.style.width,
+    bodyUserSelect: document.body.style.userSelect,
+    htmlOverflow: document.documentElement.style.overflow,
+    htmlWidth: document.documentElement.style.width,
+    htmlUserSelect: document.documentElement.style.userSelect,
+  }))
+}
+
+async function readOutsideRouting(page: BrowserPage) {
+  return page.evaluate(() => {
+    const wheel = new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true })
+    const key = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+    window.dispatchEvent(wheel)
+    document.dispatchEvent(key)
+    return { wheel: wheel.defaultPrevented, key: key.defaultPrevented }
+  })
+}
+
+async function installFullscreenStub(page: BrowserPage) {
+  await page.addInitScript(() => {
+    const defineWritable = (target: object, key: string, value: unknown) => {
+      try {
+        Object.defineProperty(target, key, { value, writable: true, configurable: true })
+      }
+      catch {
+        // ignore
+      }
+    }
+
+    defineWritable(document, 'fullScreen', false)
+    defineWritable(document, 'fullscreenElement', null)
+    defineWritable(document, 'exitFullscreen', async () => {
+      ;(document as { fullScreen?: boolean }).fullScreen = false
+      ;(document as { fullscreenElement?: Element | null }).fullscreenElement = null
+      document.dispatchEvent(new Event('fullscreenchange'))
+    })
+    defineWritable(HTMLElement.prototype, 'requestFullscreen', async function (this: HTMLElement) {
+      ;(document as { fullScreen?: boolean }).fullScreen = true
+      ;(document as { fullscreenElement?: Element | null }).fullscreenElement = this
+      document.dispatchEvent(new Event('fullscreenchange'))
+    })
+  })
+}
+
 describe('expand/fullscreen toolbars', async () => {
   await setup({
     rootDir,
     browser: true,
   })
 
-  it('opens expand overlay, zooms, shows hint, and closes', { timeout: 20000 }, async () => {
+  it('proves the complete expand lifecycle through toolbar and diagram entry', { timeout: 20000 }, async () => {
     const page = await createPage()
     await page.goto(url('/'))
 
@@ -24,6 +82,12 @@ describe('expand/fullscreen toolbars', async () => {
 
     await page.getByLabel('Expand diagram').click()
     await page.waitForSelector('.ncm-expand-modal', { state: 'visible', timeout: 5000 })
+
+    expect(await page.locator('body > .ncm-expand-modal').count()).toBe(1)
+    expect(await page.locator('.mermaid-wrapper.ncm-expand-hidden #mock-svg').count()).toBe(1)
+    expect(await page.locator('.ncm-expand-modal > .ncm-expand-overlay.ncm-expand-overlay-visible').count()).toBe(1)
+    expect(await page.locator('.ncm-expand-content > .ncm-expand-target > svg[id^="mock-svg-ncm-"]').count()).toBe(1)
+    expect(await page.getByLabel('Minimize diagram').getAttribute('type')).toBe('button')
 
     const overlayZoomInfo = page.locator('.ncm-zoom-toolbar--overlay .ncm-zoom-info')
     const initialOverlayPercent = parsePercent(await overlayZoomInfo.textContent())
@@ -43,39 +107,80 @@ describe('expand/fullscreen toolbars', async () => {
 
     await page.getByLabel('Minimize diagram').click()
     await page.waitForSelector('.ncm-expand-modal', { state: 'detached', timeout: 5000 })
+    expect(await page.locator('.mermaid-wrapper.ncm-expand-hidden').count()).toBe(0)
+
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
+
+    await page.locator('#mock-svg').click()
+    await page.waitForSelector('body > .ncm-expand-modal', { state: 'visible', timeout: 5000 })
+
+    const spaceLocked = await page.evaluate(() => {
+      const event = new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true })
+      document.dispatchEvent(event)
+      return {
+        prevented: event.defaultPrevented,
+        body: document.body.style.userSelect,
+        html: document.documentElement.style.userSelect,
+      }
+    })
+    expect(spaceLocked).toEqual({ prevented: true, body: 'none', html: 'none' })
+
+    await page.getByLabel('Minimize diagram').click()
+    await page.waitForSelector('.ncm-expand-modal', { state: 'detached', timeout: 5000 })
+
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
+    expect(await readPageStyles(page)).toEqual(restoredPageStyles)
+
+    const openThenClose = async (close: () => Promise<unknown>) => {
+      await page.locator('#mock-svg').click()
+      await page.waitForSelector('.ncm-expand-modal', { state: 'visible', timeout: 5000 })
+      await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())))
+      await close()
+      await page.waitForSelector('.ncm-expand-modal', { state: 'detached', timeout: 5000 })
+    }
+
+    await openThenClose(() => page.evaluate(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    }))
+    await openThenClose(() => page.locator('.ncm-expand-overlay').dispatchEvent('click'))
+    await openThenClose(() => page.evaluate(() => {
+      document.querySelector('.ncm-expand-overlay')
+        ?.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }))
+    }))
+    await openThenClose(() => page.evaluate(() => {
+      const createTouchEvent = (type: string, screenY: number) => {
+        const event = new Event(type, { bubbles: true, cancelable: true })
+        const touch = { screenY }
+        Object.defineProperties(event, {
+          touches: { value: [touch] },
+          changedTouches: { value: [touch] },
+        })
+        return event
+      }
+      window.dispatchEvent(createTouchEvent('touchstart', 10))
+      window.dispatchEvent(createTouchEvent('touchmove', 30))
+    }))
+
+    await page.locator('#mock-svg').click()
+    await page.waitForSelector('.ncm-expand-modal', { state: 'visible', timeout: 5000 })
+    await page.evaluate(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true }))
+      document.querySelector<HTMLButtonElement>('#unmount-diagram')?.click()
+    })
+    await page.waitForSelector('#diagram-root', { state: 'detached', timeout: 5000 })
+    await page.waitForSelector('.ncm-expand-modal', { state: 'detached', timeout: 5000 })
+
+    expect(await readPageStyles(page)).toEqual(restoredPageStyles)
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
   })
 
   it('toggles fullscreen toolbar, zooms, and shows hint', { timeout: 20000 }, async () => {
     const page = await createPage()
-
-    await page.addInitScript(() => {
-      const defineWritable = (target: object, key: string, value: unknown) => {
-        try {
-          Object.defineProperty(target, key, { value, writable: true, configurable: true })
-        }
-        catch {
-          // ignore
-        }
-      }
-
-      defineWritable(document, 'fullScreen', false)
-      defineWritable(document, 'fullscreenElement', null)
-      defineWritable(document, 'exitFullscreen', async () => {
-        ;(document as { fullScreen?: boolean }).fullScreen = false
-        ;(document as { fullscreenElement?: Element | null }).fullscreenElement = null
-        document.dispatchEvent(new Event('fullscreenchange'))
-      })
-      defineWritable(HTMLElement.prototype, 'requestFullscreen', async function (this: HTMLElement) {
-        ;(document as { fullScreen?: boolean }).fullScreen = true
-        ;(document as { fullscreenElement?: Element | null }).fullscreenElement = this
-        document.dispatchEvent(new Event('fullscreenchange'))
-      })
-    })
-
+    await installFullscreenStub(page)
     await page.goto(url('/'))
     await page.waitForSelector('#mock-svg', { state: 'visible', timeout: 5000 })
 
-    await page.getByLabel('Enter fullscreen').click()
+    await page.getByLabel('Enter fullscreen').click({ timeout: 5000 })
     await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
     expect(await page.locator('.ncm-fullscreen-zoom-hint').count()).toBe(0)
 
@@ -83,7 +188,8 @@ describe('expand/fullscreen toolbars', async () => {
     const initialFullscreenPercent = parsePercent(await fullscreenZoomInfo.textContent())
     expect(Number.isFinite(initialFullscreenPercent)).toBe(true)
 
-    await page.locator('.ncm-zoom-toolbar--fullscreen button[aria-label="Zoom In"]').click()
+    await page.waitForTimeout(100)
+    await page.locator('.ncm-zoom-toolbar--fullscreen button[aria-label="Zoom In"]').dispatchEvent('click')
     await page.waitForTimeout(100)
     const afterFullscreenPercent = parsePercent(await fullscreenZoomInfo.textContent())
     expect(afterFullscreenPercent).toBeGreaterThan(initialFullscreenPercent)
@@ -95,7 +201,8 @@ describe('expand/fullscreen toolbars', async () => {
     const hintText = await page.locator('.ncm-fullscreen-zoom-hint').textContent()
     expect(hintText).toContain('Scroll to zoom')
 
-    await page.getByLabel('Exit fullscreen').click()
+    await page.getByLabel('Exit fullscreen').click({ timeout: 5000 })
     await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'detached', timeout: 5000 })
+    await page.close()
   })
 })

--- a/test/fixtures/expand-toolbar/app.vue
+++ b/test/fixtures/expand-toolbar/app.vue
@@ -1,12 +1,23 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 const code = 'graph TD;A-->B;B-->C;'
 const encoded = computed(() => encodeURIComponent(code))
+const showDiagram = ref(true)
 </script>
 
 <template>
-  <div id="diagram-root">
+  <button
+    id="unmount-diagram"
+    type="button"
+    @click="showDiagram = false"
+  >
+    Unmount diagram
+  </button>
+  <div
+    v-if="showDiagram"
+    id="diagram-root"
+  >
     <Mermaid :code="encoded" />
   </div>
 </template>

--- a/test/useMermaidExpand.test.ts
+++ b/test/useMermaidExpand.test.ts
@@ -1,181 +1,274 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { effectScope, nextTick, ref } from 'vue'
 import { useMermaidExpand } from '../src/runtime/composables/useMermaidExpand'
+import { DEFAULT_EXPAND_OPTIONS } from '../src/runtime/constants'
+import type { ExpandOptions } from '../src/runtime/types/expand'
 
-type ListenerMap = Map<string, Set<(event: Event) => void>>
+type Listener = (event: Event) => void
 
-const createListenerRegistry = () => {
-  const listeners: ListenerMap = new Map()
-  const add = vi.fn((event: string, handler: (event: Event) => void) => {
-    if (!listeners.has(event)) listeners.set(event, new Set())
-    listeners.get(event)?.add(handler)
-  })
-  const remove = vi.fn((event: string, handler: (event: Event) => void) => {
-    listeners.get(event)?.delete(handler)
-  })
-  const get = (event: string) => Array.from(listeners.get(event) ?? [])
-  return { add, remove, get }
+function createEventTarget<T extends Record<string, unknown>>(extra: T = {} as T) {
+  const listeners = new Map<string, Set<Listener>>()
+  return {
+    ...extra,
+    addEventListener: vi.fn((type: string, listener: Listener) => {
+      const handlers = listeners.get(type) ?? new Set<Listener>()
+      handlers.add(listener)
+      listeners.set(type, handlers)
+    }),
+    removeEventListener: vi.fn((type: string, listener: Listener) => listeners.get(type)?.delete(listener)),
+    dispatch(type: string, event: Record<string, unknown> = {}) {
+      for (const listener of listeners.get(type) ?? []) listener(event as unknown as Event)
+    },
+    listenerCount(type: string) {
+      return listeners.get(type)?.size ?? 0
+    },
+  }
 }
 
-const createSvgStub = (rect: { top: number, left: number, width: number, height: number }) => {
-  const createNode = () => ({
+function createSvgStub(rect: { top: number, left: number, width: number, height: number }) {
+  const createNode = (): Record<string, unknown> => ({
     id: '',
-    style: {} as Record<string, string>,
+    style: {},
     getBoundingClientRect: () => rect,
     cloneNode: () => createNode(),
     querySelectorAll: vi.fn(() => []),
     removeAttribute: vi.fn(),
     hasAttribute: vi.fn(() => false),
+    contains: vi.fn((target: unknown) => target === svg),
   })
-  return createNode()
+  const svg = createNode()
+  return svg
 }
 
-const createWrapStub = () => {
-  return {
+function createElement(className = '') {
+  const children: unknown[] = []
+  let textContent = ''
+  const element = createEventTarget({
     nodeType: 1,
-    textContent: '',
     style: {} as Record<string, string>,
-    children: [] as unknown[],
+    children,
+    classList: { contains: (name: string) => className.split(' ').includes(name) },
     appendChild(child: unknown) {
-      this.children.push(child)
+      children.push(child)
     },
     contains(target: unknown) {
-      return this.children.includes(target)
+      return children.includes(target)
+    },
+  })
+  Object.defineProperty(element, 'textContent', {
+    get: () => textContent,
+    set: (value: string) => {
+      textContent = value
+      if (value === '') children.splice(0)
+    },
+  })
+  return element as typeof element & { textContent: string }
+}
+
+function createBrowser() {
+  let rafId = 0
+  const rafs = new Map<number, FrameRequestCallback>()
+  const rafHistory: FrameRequestCallback[] = []
+  const visualViewport = createEventTarget({ width: 1000, height: 800, scale: 1 })
+  const documentElement = { style: { overflow: 'visible', width: '120px', userSelect: 'text' }, clientWidth: 980 }
+  const body = { style: { overflow: 'auto', width: '80px', userSelect: 'text' }, offsetHeight: 0 }
+  const documentTarget = createEventTarget({ documentElement, body })
+  const windowTarget = createEventTarget({
+    innerWidth: 1000,
+    innerHeight: 800,
+    visualViewport,
+    document: documentTarget,
+    getComputedStyle: vi.fn(() => ({ transitionDuration: '0s' })),
+  })
+
+  vi.stubGlobal('document', documentTarget)
+  vi.stubGlobal('window', windowTarget)
+  vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+    const id = ++rafId
+    rafs.set(id, callback)
+    rafHistory.push(callback)
+    return id
+  }))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => rafs.delete(id)))
+
+  return {
+    documentTarget,
+    windowTarget,
+    visualViewport,
+    rafHistory,
+    flushRafs() {
+      const pending = [...rafs.entries()]
+      rafs.clear()
+      pending.forEach(([, callback]) => callback(0))
     },
   }
 }
 
-const createBrowserStubs = () => {
-  const windowListeners = createListenerRegistry()
-  const documentListeners = createListenerRegistry()
-  const documentElementStyle = { overflow: 'visible', width: '120px', userSelect: '' }
-  const bodyStyle = { overflow: 'auto', width: '80px', userSelect: '' }
-  const stubDocument = {
-    addEventListener: documentListeners.add,
-    removeEventListener: documentListeners.remove,
-    documentElement: { style: documentElementStyle, clientWidth: 1000 },
-    body: { style: bodyStyle, offsetHeight: 0 },
-  }
-  const stubWindow = {
-    innerWidth: 1000,
-    innerHeight: 800,
-    addEventListener: windowListeners.add,
-    removeEventListener: windowListeners.remove,
-    getComputedStyle: vi.fn(() => ({ transitionDuration: '0s' })),
-    document: stubDocument,
-  }
-
-  vi.stubGlobal('window', stubWindow)
-  vi.stubGlobal('document', stubDocument)
-  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-    cb(0)
-    return 1
+function setupExpand(options: ExpandOptions = DEFAULT_EXPAND_OPTIONS) {
+  const svg = createSvgStub({ top: 10, left: 20, width: 200, height: 100 })
+  const target = createElement('ncm-expand-target')
+  const modal = createElement('ncm-expand-modal')
+  const blocked = ref(false)
+  const expand = useMermaidExpand({
+    getExpandTarget: () => svg as unknown as SVGElement,
+    expandOptions: options,
+    isBlocked: blocked,
   })
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-
-  return { windowListeners, documentListeners, stubDocument }
+  expand.setExpandTargetWrap(target as unknown as Element)
+  expand.setExpandModal(modal as unknown as Element)
+  return { expand, svg, target, modal, blocked }
 }
 
-const openExpand = async (expand: ReturnType<typeof useMermaidExpand>) => {
-  expand.openExpand()
+async function openExpand(expand: ReturnType<typeof useMermaidExpand>, browser: ReturnType<typeof createBrowser>) {
+  expand.toggle()
   await nextTick()
+  browser.flushRafs()
   await nextTick()
+}
+
+function finishClose(target: ReturnType<typeof createElement>) {
+  target.dispatch('transitionend', { propertyName: 'transform' })
 }
 
 describe('useMermaidExpand', () => {
-  let windowListeners: ReturnType<typeof createListenerRegistry>
-  let documentListeners: ReturnType<typeof createListenerRegistry>
+  let browser: ReturnType<typeof createBrowser>
 
   beforeEach(() => {
-    const stubs = createBrowserStubs()
-    windowListeners = stubs.windowListeners
-    documentListeners = stubs.documentListeners
+    vi.useFakeTimers()
+    browser = createBrowser()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
-  it('expands and collapses with scroll lock', async () => {
-    const svg = createSvgStub({ top: 10, left: 20, width: 200, height: 100 })
-    const wrap = createWrapStub()
-    const expand = useMermaidExpand({
-      getExpandTarget: () => svg as unknown as SVGElement,
-    })
+  it('opens with a fitted SVG clone and scroll lock, then restores the page after close', async () => {
+    const { expand, target } = setupExpand()
 
-    expand.setExpandTargetWrap(wrap as unknown as Element)
-
-    await openExpand(expand)
+    await openExpand(expand, browser)
 
     expect(expand.isExpandActive.value).toBe(true)
     expect(expand.isVisible.value).toBe(true)
+    expect(target.children).toHaveLength(1)
+    expect(expand.expandTargetStyle.value.transform).toContain('scale(5)')
     expect(document.body.style.overflow).toBe('hidden')
     expect(document.documentElement.style.overflow).toBe('hidden')
 
-    expand.closeExpand()
-    expect(expand.isVisible.value).toBe(false)
-    expand.handleExpandTransitionEnd({ propertyName: 'transform' } as TransitionEvent)
+    expand.toggle()
+    finishClose(target)
 
     expect(expand.isExpandActive.value).toBe(false)
+    expect(target.children).toHaveLength(0)
+    expect(target.textContent).toBe('')
+    expect(document.body.style).toMatchObject({ overflow: 'auto', width: '80px' })
+    expect(document.documentElement.style).toMatchObject({ overflow: 'visible', width: '120px' })
+  })
+
+  it.each([
+    ['Escape', (_ctx: ReturnType<typeof setupExpand>) => browser.documentTarget.dispatch('keydown', { key: 'Escape', preventDefault: vi.fn(), stopPropagation: vi.fn() })],
+    ['outside wheel', (_ctx: ReturnType<typeof setupExpand>) => browser.windowTarget.dispatch('wheel', { target: {}, ctrlKey: false, metaKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn() })],
+    ['swipe', (_ctx: ReturnType<typeof setupExpand>) => {
+      browser.windowTarget.dispatch('touchstart', { touches: [{}], changedTouches: [{ screenY: 10 }] })
+      browser.windowTarget.dispatch('touchmove', { touches: [{}], changedTouches: [{ screenY: 30 }] })
+    }],
+    ['overlay click', (ctx: ReturnType<typeof setupExpand>) => ctx.modal.dispatch('click', { target: ctx.modal, stopPropagation: vi.fn() })],
+    ['close button', (ctx: ReturnType<typeof setupExpand>) => ctx.expand.closeFromButton()],
+  ])('honors the %s close policy', async (_label, close) => {
+    const ctx = setupExpand()
+    await openExpand(ctx.expand, browser)
+    close(ctx)
+    await nextTick()
+    expect(ctx.expand.isVisible.value).toBe(false)
+    finishClose(ctx.target)
+    expect(ctx.expand.isExpandActive.value).toBe(false)
+  })
+
+  it('keeps every configured close exit disabled', async () => {
+    const ctx = setupExpand({
+      ...DEFAULT_EXPAND_OPTIONS,
+      invokeCloseOn: { esc: false, wheel: false, swipe: false, overlayClick: false, closeButtonClick: false },
+    })
+    await openExpand(ctx.expand, browser)
+
+    browser.documentTarget.dispatch('keydown', { key: 'Escape', preventDefault: vi.fn(), stopPropagation: vi.fn() })
+    browser.windowTarget.dispatch('wheel', { target: {}, ctrlKey: false, metaKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn() })
+    browser.windowTarget.dispatch('touchstart', { touches: [{}], changedTouches: [{ screenY: 10 }] })
+    browser.windowTarget.dispatch('touchmove', { touches: [{}], changedTouches: [{ screenY: 30 }] })
+    ctx.modal.dispatch('click', { target: ctx.modal, stopPropagation: vi.fn() })
+    ctx.expand.closeFromButton()
+    await nextTick()
+
+    expect(ctx.expand.isVisible.value).toBe(true)
+  })
+
+  it.each(['resize', 'orientationchange', 'visual viewport resize'])('refits after %s and cancels delayed refresh on close', async (eventName) => {
+    const ctx = setupExpand()
+    await openExpand(ctx.expand, browser)
+    const target = eventName === 'visual viewport resize' ? browser.visualViewport : browser.windowTarget
+    target.dispatch(eventName === 'visual viewport resize' ? 'resize' : eventName)
+    browser.flushRafs()
+    expect(ctx.expand.expandTargetStyle.value.transitionDuration).toBe('0ms')
+
+    ctx.expand.toggle()
+    finishClose(ctx.target)
+    vi.runAllTimers()
+    browser.flushRafs()
+
+    expect(ctx.expand.isExpandActive.value).toBe(false)
     expect(document.body.style.overflow).toBe('auto')
-    expect(document.documentElement.style.overflow).toBe('visible')
-    expect(document.body.style.width).toBe('80px')
-    expect(document.documentElement.style.width).toBe('120px')
   })
 
-  it('closes on Escape keydown', async () => {
-    const svg = createSvgStub({ top: 10, left: 20, width: 200, height: 100 })
-    const wrap = createWrapStub()
-    const expand = useMermaidExpand({
-      getExpandTarget: () => svg as unknown as SVGElement,
-    })
+  it.each(['close', 'replacement', 'scope disposal'])('cancels active interaction, hints, listeners and pending work on %s', async (ending) => {
+    const scope = effectScope()
+    const ctx = scope.run(() => setupExpand())!
+    await openExpand(ctx.expand, browser)
+    await nextTick()
 
-    expand.setExpandTargetWrap(wrap as unknown as Element)
-    await openExpand(expand)
+    browser.documentTarget.dispatch('keydown', { code: 'Space', repeat: false, preventDefault: vi.fn() })
+    ctx.modal.dispatch('mousedown', { preventDefault: vi.fn(), clientX: 10, clientY: 10 })
+    browser.windowTarget.dispatch('wheel', { target: ctx.target.children[0], ctrlKey: false, metaKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn() })
+    browser.windowTarget.dispatch('resize')
+    expect(document.body.style.userSelect).toBe('none')
+    expect(ctx.expand.showZoomHint.value).toBe(true)
 
-    const keydowns = documentListeners.get('keydown')
-    const event = {
-      key: 'Escape',
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-    } as unknown as KeyboardEvent
+    if (ending === 'close') {
+      ctx.expand.toggle()
+      finishClose(ctx.target)
+    }
+    else if (ending === 'replacement') {
+      ctx.expand.endForDiagramReplacement()
+    }
+    else {
+      scope.stop()
+    }
+    await nextTick()
 
-    keydowns.forEach(handler => handler(event as unknown as Event))
-    expect(event.preventDefault).toHaveBeenCalled()
-    expect(event.stopPropagation).toHaveBeenCalled()
-    expect(expand.isVisible.value).toBe(false)
+    expect(ctx.expand.isExpandActive.value).toBe(false)
+    expect(document.body.style.userSelect).toBe('text')
+    expect(document.documentElement.style.userSelect).toBe('text')
+    expect(document.body.style.overflow).toBe('auto')
+    expect(ctx.expand.showZoomHint.value).toBe(false)
+    expect(browser.windowTarget.listenerCount('wheel')).toBe(0)
+    expect(browser.documentTarget.listenerCount('keydown')).toBe(0)
 
-    expand.handleExpandTransitionEnd({ propertyName: 'transform' } as TransitionEvent)
-    expect(expand.isExpandActive.value).toBe(false)
+    vi.runAllTimers()
+    browser.flushRafs()
+    expect(document.body.style).toMatchObject({ overflow: 'auto', userSelect: 'text' })
   })
 
-  it('closes on wheel outside the diagram', async () => {
-    const svg = createSvgStub({ top: 10, left: 20, width: 200, height: 100 })
-    const wrap = createWrapStub()
-    const expand = useMermaidExpand({
-      getExpandTarget: () => svg as unknown as SVGElement,
-    })
+  it('cancels the opening frame when closed before activation', async () => {
+    const ctx = setupExpand()
+    ctx.expand.toggle()
+    await nextTick()
+    const staleOpeningFrame = browser.rafHistory[0]
 
-    expand.setExpandTargetWrap(wrap as unknown as Element)
-    await openExpand(expand)
+    ctx.expand.toggle()
+    finishClose(ctx.target)
+    staleOpeningFrame?.(0)
 
-    const wheel = windowListeners.get('wheel')[0]
-    const event = {
-      target: {},
-      ctrlKey: false,
-      metaKey: false,
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-    } as unknown as WheelEvent
-
-    wheel?.(event as unknown as Event)
-    await new Promise<void>(resolve => queueMicrotask(resolve))
-
-    expect(event.preventDefault).toHaveBeenCalledTimes(1)
-    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
-    expect(expand.isVisible.value).toBe(false)
-
-    expand.handleExpandTransitionEnd({ propertyName: 'transform' } as TransitionEvent)
-    expect(expand.isExpandActive.value).toBe(false)
+    expect(cancelAnimationFrame).toHaveBeenCalled()
+    expect(ctx.expand.isExpandActive.value).toBe(false)
+    expect(document.body.style.overflow).toBe('auto')
   })
 })


### PR DESCRIPTION
## Summary

- move Expand zoom, gestures, scheduling, environment listeners, close policies, and teardown behind the mode-owned lifecycle
- narrow the overlay/Mermaid seam to high-level intents and a read-only active outcome
- add focused lifecycle and Package User browser coverage, including render replacement and cleanup

## Verification

- `pnpm lint`
- `pnpm exec vitest run test/*.test.ts` (16 files, 92 tests)
- `pnpm test:types`
- `pnpm prepack`

Closes #17
Refs #16