### PR TITLE
refactor: deepen fullscreen lifecycle ownership

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "release:rc": "pnpm run release:base && changelogen --release --prerelease rc --push && pnpm publish --tag rc",
     "release": "pnpm run release:patch",
     "lint": "eslint .",
-    "test": "vitest run --dir test",
-    "test:watch": "vitest watch --dir test",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "release:rc": "pnpm run release:base && changelogen --release --prerelease rc --push && pnpm publish --tag rc",
     "release": "pnpm run release:patch",
     "lint": "eslint .",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
+    "test": "vitest run --dir test",
+    "test:watch": "vitest watch --dir test",
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {

--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -20,7 +20,6 @@ import { createMermaidRenderer } from '../mermaid-rendering'
 import { parseSizeToPx, isRecord } from '../utils'
 import { useMermaidTheme } from '../composables/useMermaidTheme'
 import { useMermaidCursors } from '../composables/useMermaidCursors'
-import { useMermaidFullscreen } from '../composables/useMermaidFullscreen'
 import { DEFAULT_TOOLBAR_OPTIONS, DEFAULT_EXPAND_OPTIONS } from '../constants'
 import type { ExpandOptions } from '../types/expand'
 import Spinner from './Spinner.vue'
@@ -33,9 +32,7 @@ import MermaidExpandOverlay from './MermaidExpandOverlay.vue'
 import type { MermaidToolbarOptions } from '../../types/mermaid'
 import IconExpand from './icons/IconExpand.vue'
 import IconCollapse from './icons/IconCollapse.vue'
-import MermaidZoomToolbar from './MermaidZoomToolbar.vue'
-
-const isMac = import.meta.client ? /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) : false
+import MermaidFullscreenPresentation from './MermaidFullscreenPresentation.vue'
 
 const props = defineProps<{
   // Using `unknown` to avoid Vue runtime prop type warnings when user's collection schema is misconfigured; actual validation below.
@@ -88,22 +85,23 @@ const { currentTheme: manualThemeMode } = useMermaidTheme()
 const mermaidBlock = useTemplateRef('mermaidBlock')
 const mermaidWrapper = useTemplateRef('mermaidWrapper')
 const mermaidContainer = useTemplateRef('mermaidContainer')
-const {
-  isSupported: isFullscreenSupported,
-  isActive: isFullscreen,
-  targetStyle: fullscreenTargetStyle,
-  scale: fullscreenScale,
-  showZoomHint: showFullscreenZoomHint,
-  toggle: toggleFullscreen,
-  endForDiagramReplacement: endFullscreenForDiagramReplacement,
-  zoomIn: zoomFullscreenIn,
-  zoomOut: zoomFullscreenOut,
-  resetZoom: resetFullscreenZoom,
-} = useMermaidFullscreen({
-  getFullscreenTarget: () => mermaidBlock.value,
-  getViewportTarget: () => mermaidWrapper.value,
-  getRenderTarget: () => mermaidContainer.value,
-})
+interface MermaidFullscreenPresentationExpose {
+  toggle: () => Promise<void>
+  endForDiagramReplacement: () => Promise<void>
+}
+const fullscreenPresentation = useTemplateRef<MermaidFullscreenPresentationExpose>('fullscreenPresentation')
+const isFullscreenSupported = ref(false)
+const isFullscreen = ref(false)
+const handleFullscreenSupportedChange = (supported: boolean) => {
+  isFullscreenSupported.value = supported
+}
+const handleFullscreenActiveChange = (active: boolean) => {
+  isFullscreen.value = active
+}
+const toggleFullscreen = () => {
+  expandOverlay.value?.endForDiagramReplacement()
+  return fullscreenPresentation.value?.toggle()
+}
 const hasRenderedOnce = ref(false)
 const isLoading = ref(false)
 const hasError = ref(false)
@@ -278,7 +276,7 @@ function getBuiltInRenderRequest() {
     prepare: () => {
       if (import.meta.client) {
         expandOverlay.value?.endForDiagramReplacement()
-        void endFullscreenForDiagramReplacement()
+        void fullscreenPresentation.value?.endForDiagramReplacement()
       }
 
       hasError.value = false
@@ -672,25 +670,15 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
         </div>
       </div>
 
-      <MermaidZoomToolbar
-        v-if="isFullscreen"
-        variant="fullscreen"
-        :scale="fullscreenScale"
+      <MermaidFullscreenPresentation
+        ref="fullscreenPresentation"
+        :fullscreen-target="mermaidBlock"
+        :viewport-target="mermaidWrapper"
+        :render-target="mermaidContainer"
         :icon-size="iconSize"
-        @zoom-out="zoomFullscreenOut"
-        @zoom-in="zoomFullscreenIn"
-        @reset="resetFullscreenZoom"
+        @active-change="handleFullscreenActiveChange"
+        @supported-change="handleFullscreenSupportedChange"
       />
-
-      <!-- Fullscreen Zoom Hint -->
-      <Transition name="ncm-hint-fade">
-        <div
-          v-if="showFullscreenZoomHint && isFullscreen"
-          class="ncm-fullscreen-zoom-hint"
-        >
-          {{ isMac ? '⌘' : 'Ctrl' }} + Scroll to zoom
-        </div>
-      </Transition>
 
       <!-- Diagram Container -->
       <div
@@ -708,7 +696,6 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
         <div
           ref="mermaidContainer"
           class="mermaid"
-          :style="isFullscreen ? fullscreenTargetStyle : undefined"
         >
           <!-- Initially show the slot's <pre><code> for SSR; client-side rendering will replace it with the mermaid SVG -->
           <slot>
@@ -930,45 +917,6 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
 }
 .mermaid-wrapper.ncm-expand-clickable :deep(svg) {
   cursor: var(--ncm-cursor-expand);
-}
-
-/* Fullscreen Zoom Toolbar and Hint */
-.ncm-fullscreen-zoom-hint {
-  display: none;
-}
-
-:fullscreen .ncm-fullscreen-zoom-hint {
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 12px 24px;
-  background-color: var(--ncm-hint-bg, rgba(0, 0, 0, 0.75));
-  color: var(--ncm-hint-text, #fff);
-  border-radius: var(--ncm-hint-radius, 8px);
-  font-size: 20px;
-  font-weight: 500;
-  pointer-events: none;
-  user-select: none;
-  z-index: 20;
-  white-space: nowrap;
-}
-
-.ncm-hint-fade-enter-active,
-.ncm-hint-fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-.ncm-hint-fade-enter-from,
-.ncm-hint-fade-leave-to {
-  opacity: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .ncm-hint-fade-enter-active,
-  .ncm-hint-fade-leave-active {
-    transition-duration: 0.01ms !important;
-  }
 }
 
 .mermaid-error-default {

--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -20,9 +20,7 @@ import { createMermaidRenderer } from '../mermaid-rendering'
 import { parseSizeToPx, isRecord } from '../utils'
 import { useMermaidTheme } from '../composables/useMermaidTheme'
 import { useMermaidCursors } from '../composables/useMermaidCursors'
-import { useFullscreen } from '../composables/useFullscreen'
-import { useMermaidZoom } from '../composables/useMermaidZoom'
-import { useEventListener } from '../composables/useEventListener'
+import { useMermaidFullscreen } from '../composables/useMermaidFullscreen'
 import { DEFAULT_TOOLBAR_OPTIONS, DEFAULT_EXPAND_OPTIONS } from '../constants'
 import type { ExpandOptions } from '../types/expand'
 import Spinner from './Spinner.vue'
@@ -88,7 +86,24 @@ const { $mermaid } = nuxtApp
 const { currentTheme: manualThemeMode } = useMermaidTheme()
 
 const mermaidBlock = useTemplateRef('mermaidBlock')
+const mermaidWrapper = useTemplateRef('mermaidWrapper')
 const mermaidContainer = useTemplateRef('mermaidContainer')
+const {
+  isSupported: isFullscreenSupported,
+  isActive: isFullscreen,
+  targetStyle: fullscreenTargetStyle,
+  scale: fullscreenScale,
+  showZoomHint: showFullscreenZoomHint,
+  toggle: toggleFullscreen,
+  endForDiagramReplacement: endFullscreenForDiagramReplacement,
+  zoomIn: zoomFullscreenIn,
+  zoomOut: zoomFullscreenOut,
+  resetZoom: resetFullscreenZoom,
+} = useMermaidFullscreen({
+  getFullscreenTarget: () => mermaidBlock.value,
+  getViewportTarget: () => mermaidWrapper.value,
+  getRenderTarget: () => mermaidContainer.value,
+})
 const hasRenderedOnce = ref(false)
 const isLoading = ref(false)
 const hasError = ref(false)
@@ -150,9 +165,6 @@ const copyIcon = computed(() => {
   if (copyState.value === 'copied') return IconClipboardSuccess
   if (isCopyHovered.value && hasCopySource.value) return IconClipboardHover
   return IconClipboard
-})
-const { isSupported: isFullscreenSupported, isFullscreen, toggle: toggleFullscreen } = useFullscreen(mermaidBlock, {
-  autoExit: true,
 })
 const showFullscreenButton = computed(() => toolbarButtons.value.fullscreen !== false && isFullscreenSupported.value)
 const fullscreenLabel = computed(() => isFullscreen.value ? 'Exit fullscreen' : 'Enter fullscreen')
@@ -239,139 +251,6 @@ const iconSize = computed(() => {
 })
 const isExpandBlocked = computed(() => !isEnabled || !expandEnabled || isLoading.value || hasError.value || isFullscreen.value)
 
-// Fullscreen Pan/Zoom - reuse useMermaidZoom
-const fullscreenZoom = useMermaidZoom({
-  active: isFullscreen,
-  minScale: 0.1,
-  maxScale: 10,
-})
-
-const showFullscreenZoomHint = ref(false)
-const fullscreenHintDurationMs = 3000
-let fullscreenHintTimeout: ReturnType<typeof setTimeout> | undefined
-let hasShownFullscreenZoomHint = false
-
-// Reset zoom state when entering fullscreen
-watch(isFullscreen, (value) => {
-  if (value) {
-    hasShownFullscreenZoomHint = false
-    // Use nextTick to ensure fullscreen layout is applied
-    nextTick(() => {
-      const el = mermaidContainer.value
-      if (el) {
-        const rect = el.getBoundingClientRect()
-        fullscreenZoom.init({
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-          top: rect.top,
-          left: rect.left,
-        })
-      }
-    })
-  }
-  else {
-    showFullscreenZoomHint.value = false
-    clearTimeout(fullscreenHintTimeout)
-  }
-})
-
-function refreshFullscreenOrigin() {
-  if (!import.meta.client || !isFullscreen.value) return
-  const el = mermaidContainer.value
-  if (!el) return
-  // Space switch can change the viewport coordinate system without resizing.
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      const rect = el.getBoundingClientRect()
-      fullscreenZoom.setMetrics({
-        scale: fullscreenZoom.scale.value,
-        translateX: fullscreenZoom.translateX.value,
-        translateY: fullscreenZoom.translateY.value,
-        top: rect.top,
-        left: rect.left,
-      })
-    })
-  })
-}
-
-function handleFullscreenWheel(event: WheelEvent) {
-  if (!isFullscreen.value) return
-
-  const handled = fullscreenZoom.handleWheel(event)
-  if (handled) {
-    if (fullscreenHintTimeout && showFullscreenZoomHint.value) {
-      showFullscreenZoomHint.value = false
-      clearTimeout(fullscreenHintTimeout)
-    }
-    return
-  }
-
-  // Not handled (no Ctrl/Cmd) - show hint once
-  if (!hasShownFullscreenZoomHint) {
-    hasShownFullscreenZoomHint = true
-    showFullscreenZoomHint.value = true
-    clearTimeout(fullscreenHintTimeout)
-    fullscreenHintTimeout = setTimeout(() => {
-      showFullscreenZoomHint.value = false
-    }, fullscreenHintDurationMs)
-  }
-}
-
-function handleFullscreenKeyDown(event: KeyboardEvent) {
-  if (!isFullscreen.value) return
-  if (event.defaultPrevented) return
-
-  const target = event.target as HTMLElement | null
-  if (target) {
-    const tagName = target.tagName
-    if (target.isContentEditable || tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT')
-      return
-  }
-
-  const browserZoomKeys = new Set(['+', '=', '-', '_'])
-  if (event.ctrlKey || event.metaKey) {
-    if (browserZoomKeys.has(event.key))
-      event.preventDefault()
-    return
-  }
-
-  const moveStep = 20 / fullscreenZoom.scale.value
-
-  const keyHandlers: Record<string, () => void> = {
-    '+': () => fullscreenZoom.zoomIn(),
-    '=': () => fullscreenZoom.zoomIn(),
-    '-': () => fullscreenZoom.zoomOut(),
-    '_': () => fullscreenZoom.zoomOut(),
-    '0': () => fullscreenZoom.reset(),
-    'ArrowUp': () => { fullscreenZoom.translateY.value += moveStep },
-    'ArrowDown': () => { fullscreenZoom.translateY.value -= moveStep },
-    'ArrowLeft': () => { fullscreenZoom.translateX.value += moveStep },
-    'ArrowRight': () => { fullscreenZoom.translateX.value -= moveStep },
-  }
-
-  const handler = keyHandlers[event.key]
-  if (handler) {
-    event.preventDefault()
-    handler()
-  }
-}
-
-if (import.meta.client) {
-  const fullscreenDocument = computed(() => isFullscreen.value ? document : null)
-  const fullscreenWindow = computed(() => isFullscreen.value ? window : null)
-  const fullscreenVisualViewport = computed(() => (isFullscreen.value ? window.visualViewport : null))
-
-  useEventListener(fullscreenWindow, 'wheel', handleFullscreenWheel, { passive: false })
-  useEventListener(fullscreenDocument, 'keydown', handleFullscreenKeyDown)
-  useEventListener(fullscreenWindow, 'focus', refreshFullscreenOrigin)
-  useEventListener(fullscreenDocument, 'fullscreenchange', refreshFullscreenOrigin)
-  useEventListener(fullscreenVisualViewport, 'resize', refreshFullscreenOrigin, { passive: true })
-  useEventListener(fullscreenDocument, 'visibilitychange', () => {
-    if (document.visibilityState === 'visible') refreshFullscreenOrigin()
-  })
-}
-
 interface MermaidExpandOverlayExpose {
   toggle: (event?: Event) => void
   openFromDiagram: (event: MouseEvent) => void
@@ -397,8 +276,10 @@ function getBuiltInRenderRequest() {
       target: mermaidContainer.value,
     }),
     prepare: () => {
-      if (import.meta.client)
+      if (import.meta.client) {
         expandOverlay.value?.endForDiagramReplacement()
+        void endFullscreenForDiagramReplacement()
+      }
 
       hasError.value = false
       errorContent.value = null
@@ -794,11 +675,11 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
       <MermaidZoomToolbar
         v-if="isFullscreen"
         variant="fullscreen"
-        :scale="fullscreenZoom.scale.value"
+        :scale="fullscreenScale"
         :icon-size="iconSize"
-        @zoom-out="fullscreenZoom.zoomOut()"
-        @zoom-in="fullscreenZoom.zoomIn()"
-        @reset="fullscreenZoom.reset()"
+        @zoom-out="zoomFullscreenOut"
+        @zoom-in="zoomFullscreenIn"
+        @reset="resetFullscreenZoom"
       />
 
       <!-- Fullscreen Zoom Hint -->
@@ -813,6 +694,7 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
 
       <!-- Diagram Container -->
       <div
+        ref="mermaidWrapper"
         class="mermaid-wrapper"
         :class="{
           'ncm-is-loading': isLoading && !hasRenderedOnce,
@@ -822,20 +704,11 @@ const { cursorVariables } = useMermaidCursors(iconSize, expandEnabled)
         }"
         :style="cursorVariables"
         @click="handleMermaidClick"
-        @mousedown="isFullscreen && fullscreenZoom.handleDragStart($event)"
-        @mousemove="isFullscreen && fullscreenZoom.handleDragMove($event)"
-        @touchstart="isFullscreen && fullscreenZoom.handleDragStart($event)"
-        @touchmove="isFullscreen && fullscreenZoom.handleDragMove($event)"
-        @touchend="isFullscreen && fullscreenZoom.handleDragEnd()"
       >
         <div
           ref="mermaidContainer"
           class="mermaid"
-          :style="isFullscreen ? {
-            transform: fullscreenZoom.transformStyle.value.transform,
-            transformOrigin: '0 0',
-            cursor: fullscreenZoom.cursor.value,
-          } : undefined"
+          :style="isFullscreen ? fullscreenTargetStyle : undefined"
         >
           <!-- Initially show the slot's <pre><code> for SSR; client-side rendering will replace it with the mermaid SVG -->
           <slot>

--- a/src/runtime/components/MermaidFullscreenPresentation.vue
+++ b/src/runtime/components/MermaidFullscreenPresentation.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useMermaidFullscreen } from '../composables/useMermaidFullscreen'
+import MermaidZoomToolbar from './MermaidZoomToolbar.vue'
+
+const props = defineProps<{
+  fullscreenTarget: HTMLElement | null
+  viewportTarget: HTMLElement | null
+  renderTarget: HTMLElement | null
+  iconSize?: number
+}>()
+
+const emit = defineEmits<{
+  (e: 'active-change' | 'supported-change', value: boolean): void
+}>()
+
+const isMac = import.meta.client ? /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) : false
+const {
+  isSupported,
+  isActive,
+  scale,
+  showZoomHint,
+  toggle,
+  endForDiagramReplacement,
+  zoomIn,
+  zoomOut,
+  resetZoom,
+} = useMermaidFullscreen({
+  getFullscreenTarget: () => props.fullscreenTarget,
+  getViewportTarget: () => props.viewportTarget,
+  getRenderTarget: () => props.renderTarget,
+})
+
+watch(isActive, active => emit('active-change', active), { flush: 'sync', immediate: true })
+watch(isSupported, supported => emit('supported-change', supported), { flush: 'sync', immediate: true })
+
+defineExpose({ toggle, endForDiagramReplacement })
+</script>
+
+<template>
+  <MermaidZoomToolbar
+    v-if="isActive"
+    variant="fullscreen"
+    :scale="scale"
+    :icon-size="iconSize"
+    @zoom-out="zoomOut"
+    @zoom-in="zoomIn"
+    @reset="resetZoom"
+  />
+
+  <Transition name="ncm-hint-fade">
+    <div
+      v-if="showZoomHint && isActive"
+      class="ncm-fullscreen-zoom-hint"
+    >
+      {{ isMac ? '⌘' : 'Ctrl' }} + Scroll to zoom
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.ncm-fullscreen-zoom-hint {
+  display: none;
+}
+
+:fullscreen .ncm-fullscreen-zoom-hint {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 12px 24px;
+  background-color: var(--ncm-hint-bg, rgba(0, 0, 0, 0.75));
+  color: var(--ncm-hint-text, #fff);
+  border-radius: var(--ncm-hint-radius, 8px);
+  font-size: 20px;
+  font-weight: 500;
+  pointer-events: none;
+  user-select: none;
+  z-index: 20;
+  white-space: nowrap;
+}
+
+.ncm-hint-fade-enter-active,
+.ncm-hint-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.ncm-hint-fade-enter-from,
+.ncm-hint-fade-leave-to {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ncm-hint-fade-enter-active,
+  .ncm-hint-fade-leave-active {
+    transition-duration: 0.01ms !important;
+  }
+}
+</style>

--- a/src/runtime/composables/useMermaidFullscreen.ts
+++ b/src/runtime/composables/useMermaidFullscreen.ts
@@ -1,0 +1,230 @@
+import { computed, nextTick, ref, watch } from 'vue'
+import type { CSSProperties } from 'vue'
+import type { ConfigurableDocument, ConfigurableWindow } from './_configurable'
+import { tryOnScopeDispose } from './shared'
+import { useEventListener } from './useEventListener'
+import { useFullscreen } from './useFullscreen'
+import { useMermaidZoom } from './useMermaidZoom'
+
+interface UseMermaidFullscreenOptions extends ConfigurableDocument, ConfigurableWindow {
+  getFullscreenTarget: () => HTMLElement | null
+  getViewportTarget: () => HTMLElement | null
+  getRenderTarget: () => HTMLElement | null
+}
+
+const hintDurationMs = 3000
+
+export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
+  const browserDocument = options.document
+    ?? (typeof document === 'undefined' ? undefined : document)
+  const browserWindow = options.window
+    ?? (typeof window === 'undefined' ? undefined : window)
+  const fullscreenTarget = computed(() => options.getFullscreenTarget())
+  const fullscreen = useFullscreen(fullscreenTarget, {
+    document: browserDocument,
+  })
+  const isActive = fullscreen.isFullscreen
+  const zoom = useMermaidZoom({
+    active: isActive,
+    minScale: 0.1,
+    maxScale: 10,
+  })
+  const showZoomHint = ref(false)
+  let hasShownZoomHint = false
+  let hintTimeout: ReturnType<typeof setTimeout> | undefined
+  let refreshRaf1: number | undefined
+  let refreshRaf2: number | undefined
+  let lifecycleId = 0
+
+  const targetStyle = computed<CSSProperties>(() => ({
+    ...zoom.transformStyle.value,
+    transformOrigin: '0 0',
+    cursor: zoom.cursor.value,
+  }))
+
+  function clearScheduledViewportWork() {
+    if (refreshRaf1 != null) cancelAnimationFrame(refreshRaf1)
+    if (refreshRaf2 != null) cancelAnimationFrame(refreshRaf2)
+    refreshRaf1 = undefined
+    refreshRaf2 = undefined
+  }
+
+  function resetPresentation() {
+    zoom.init({
+      scale: 1,
+      translateX: 0,
+      translateY: 0,
+      top: 0,
+      left: 0,
+    })
+  }
+
+  function stopLifecycle() {
+    lifecycleId++
+    clearTimeout(hintTimeout)
+    hintTimeout = undefined
+    clearScheduledViewportWork()
+    showZoomHint.value = false
+    zoom.cancelInteraction()
+    resetPresentation()
+  }
+
+  function initializeViewport(id: number) {
+    if (!isActive.value || id !== lifecycleId) return
+    const target = options.getRenderTarget()
+    if (!target) return
+    const rect = target.getBoundingClientRect()
+    zoom.init({
+      scale: 1,
+      translateX: 0,
+      translateY: 0,
+      top: rect.top,
+      left: rect.left,
+    })
+  }
+
+  function startLifecycle() {
+    const id = ++lifecycleId
+    hasShownZoomHint = false
+    clearTimeout(hintTimeout)
+    hintTimeout = undefined
+    showZoomHint.value = false
+    nextTick(() => initializeViewport(id))
+  }
+
+  watch(isActive, (active) => {
+    if (active) startLifecycle()
+    else stopLifecycle()
+  }, { flush: 'sync' })
+
+  function refreshViewportOrigin() {
+    if (!isActive.value) return
+    const id = lifecycleId
+    clearScheduledViewportWork()
+    refreshRaf1 = requestAnimationFrame(() => {
+      refreshRaf1 = undefined
+      if (!isActive.value || id !== lifecycleId) return
+      refreshRaf2 = requestAnimationFrame(() => {
+        refreshRaf2 = undefined
+        if (!isActive.value || id !== lifecycleId) return
+        const target = options.getRenderTarget()
+        if (!target) return
+        const rect = target.getBoundingClientRect()
+        zoom.setMetrics({
+          scale: zoom.scale.value,
+          translateX: zoom.translateX.value,
+          translateY: zoom.translateY.value,
+          top: rect.top,
+          left: rect.left,
+        })
+      })
+    })
+  }
+
+  function hideZoomHint() {
+    clearTimeout(hintTimeout)
+    hintTimeout = undefined
+    showZoomHint.value = false
+  }
+
+  function handleWheel(event: WheelEvent) {
+    if (zoom.handleWheel(event)) {
+      if (showZoomHint.value) hideZoomHint()
+      return
+    }
+
+    if (hasShownZoomHint) return
+    hasShownZoomHint = true
+    showZoomHint.value = true
+    clearTimeout(hintTimeout)
+    hintTimeout = setTimeout(() => {
+      showZoomHint.value = false
+      hintTimeout = undefined
+    }, hintDurationMs)
+  }
+
+  function isEditableTarget(target: EventTarget | null) {
+    if (!target || typeof target !== 'object') return false
+    const element = target as HTMLElement
+    const tagName = element.tagName
+    return element.isContentEditable
+      || tagName === 'INPUT'
+      || tagName === 'TEXTAREA'
+      || tagName === 'SELECT'
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.defaultPrevented || isEditableTarget(event.target)) return
+
+    const browserZoomKeys = new Set(['+', '=', '-', '_'])
+    if (event.ctrlKey || event.metaKey) {
+      if (browserZoomKeys.has(event.key)) event.preventDefault()
+      return
+    }
+
+    const moveStep = 20 / zoom.scale.value
+    const keyHandlers: Record<string, () => void> = {
+      '+': zoom.zoomIn,
+      '=': zoom.zoomIn,
+      '-': zoom.zoomOut,
+      '_': zoom.zoomOut,
+      '0': zoom.reset,
+      'ArrowUp': () => { zoom.translateY.value += moveStep },
+      'ArrowDown': () => { zoom.translateY.value -= moveStep },
+      'ArrowLeft': () => { zoom.translateX.value += moveStep },
+      'ArrowRight': () => { zoom.translateX.value -= moveStep },
+    }
+    const handler = keyHandlers[event.key]
+    if (!handler) return
+    event.preventDefault()
+    handler()
+  }
+
+  if (browserDocument && browserWindow) {
+    const activeWindow = computed(() => isActive.value ? browserWindow : null)
+    const activeDocument = computed(() => isActive.value ? browserDocument : null)
+    const activeVisualViewport = computed(() => isActive.value ? browserWindow.visualViewport : null)
+    const activeViewport = computed(() => isActive.value ? options.getViewportTarget() : null)
+
+    useEventListener(activeWindow, 'wheel', handleWheel, { passive: false })
+    useEventListener(activeDocument, 'keydown', handleKeyDown)
+    useEventListener(activeWindow, 'focus', refreshViewportOrigin)
+    useEventListener(activeDocument, 'fullscreenchange', refreshViewportOrigin)
+    useEventListener(activeVisualViewport, 'resize', refreshViewportOrigin, { passive: true })
+    useEventListener(activeDocument, 'visibilitychange', () => {
+      if (browserDocument.visibilityState === 'visible') refreshViewportOrigin()
+    })
+    useEventListener(activeViewport, 'mousedown', zoom.handleDragStart)
+    useEventListener(activeViewport, 'mousemove', zoom.handleDragMove)
+    useEventListener(activeViewport, 'touchstart', zoom.handleDragStart)
+    useEventListener(activeViewport, 'touchmove', zoom.handleDragMove)
+    useEventListener(activeViewport, 'touchend', zoom.handleDragEnd)
+  }
+
+  async function toggle() {
+    await fullscreen.toggle()
+  }
+
+  async function endForDiagramReplacement() {
+    stopLifecycle()
+    await fullscreen.exit()
+  }
+
+  tryOnScopeDispose(() => {
+    stopLifecycle()
+    void fullscreen.exit()
+  })
+
+  return {
+    isSupported: fullscreen.isSupported,
+    isActive,
+    targetStyle,
+    scale: computed(() => zoom.scale.value),
+    showZoomHint,
+    toggle,
+    endForDiagramReplacement,
+    zoomIn: zoom.zoomIn,
+    zoomOut: zoom.zoomOut,
+    resetZoom: zoom.reset,
+  }
+}

--- a/src/runtime/composables/useMermaidFullscreen.ts
+++ b/src/runtime/composables/useMermaidFullscreen.ts
@@ -1,5 +1,6 @@
 import { computed, nextTick, ref, watch } from 'vue'
 import type { CSSProperties } from 'vue'
+import { FULLSCREEN_ZOOM_HINT_DURATION_MS } from '../constants'
 import type { ConfigurableDocument, ConfigurableWindow } from './_configurable'
 import { tryOnScopeDispose } from './shared'
 import { useEventListener } from './useEventListener'
@@ -12,28 +13,31 @@ interface UseMermaidFullscreenOptions extends ConfigurableDocument, Configurable
   getRenderTarget: () => HTMLElement | null
 }
 
-const hintDurationMs = 3000
-
 export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   const browserDocument = options.document
     ?? (typeof document === 'undefined' ? undefined : document)
   const browserWindow = options.window
     ?? (typeof window === 'undefined' ? undefined : window)
   const fullscreenTarget = computed(() => options.getFullscreenTarget())
+  const renderTarget = computed(() => options.getRenderTarget())
   const fullscreen = useFullscreen(fullscreenTarget, {
     document: browserDocument,
   })
   const isActive = fullscreen.isFullscreen
+  const interactionActive = ref(false)
   const zoom = useMermaidZoom({
-    active: isActive,
+    active: interactionActive,
     minScale: 0.1,
     maxScale: 10,
+    document: browserDocument,
+    window: browserWindow,
   })
   const showZoomHint = ref(false)
   let hasShownZoomHint = false
   let hintTimeout: ReturnType<typeof setTimeout> | undefined
   let refreshRaf1: number | undefined
   let refreshRaf2: number | undefined
+  // Invalidates nextTick and RAF work when an exit races queued initialization or refresh.
   let lifecycleId = 0
 
   const targetStyle = computed<CSSProperties>(() => ({
@@ -41,10 +45,39 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
     transformOrigin: '0 0',
     cursor: zoom.cursor.value,
   }))
+  let styledTarget: HTMLElement | null = null
+  let originalTargetStyle = { transform: '', transformOrigin: '', cursor: '' }
+
+  function restoreTargetStyle() {
+    if (!styledTarget) return
+    Object.assign(styledTarget.style, originalTargetStyle)
+    styledTarget = null
+  }
+
+  function syncTargetStyle() {
+    const target = interactionActive.value ? renderTarget.value : null
+    if (styledTarget !== target) {
+      restoreTargetStyle()
+      if (target) {
+        styledTarget = target
+        originalTargetStyle = {
+          transform: target.style.transform,
+          transformOrigin: target.style.transformOrigin,
+          cursor: target.style.cursor,
+        }
+      }
+    }
+    if (!styledTarget) return
+    styledTarget.style.transform = targetStyle.value.transform as string
+    styledTarget.style.transformOrigin = targetStyle.value.transformOrigin as string
+    styledTarget.style.cursor = targetStyle.value.cursor as string
+  }
+
+  watch([interactionActive, targetStyle, renderTarget], syncTargetStyle, { flush: 'sync' })
 
   function clearScheduledViewportWork() {
-    if (refreshRaf1 != null) cancelAnimationFrame(refreshRaf1)
-    if (refreshRaf2 != null) cancelAnimationFrame(refreshRaf2)
+    if (refreshRaf1 != null) browserWindow?.cancelAnimationFrame(refreshRaf1)
+    if (refreshRaf2 != null) browserWindow?.cancelAnimationFrame(refreshRaf2)
     refreshRaf1 = undefined
     refreshRaf2 = undefined
   }
@@ -60,18 +93,18 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   }
 
   function stopLifecycle() {
+    interactionActive.value = false
+    restoreTargetStyle()
     lifecycleId++
-    clearTimeout(hintTimeout)
-    hintTimeout = undefined
+    hideZoomHint()
     clearScheduledViewportWork()
-    showZoomHint.value = false
     zoom.cancelInteraction()
     resetPresentation()
   }
 
   function initializeViewport(id: number) {
-    if (!isActive.value || id !== lifecycleId) return
-    const target = options.getRenderTarget()
+    if (!interactionActive.value || !isActive.value || id !== lifecycleId) return
+    const target = renderTarget.value
     if (!target) return
     const rect = target.getBoundingClientRect()
     zoom.init({
@@ -85,10 +118,9 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
 
   function startLifecycle() {
     const id = ++lifecycleId
+    interactionActive.value = true
     hasShownZoomHint = false
-    clearTimeout(hintTimeout)
-    hintTimeout = undefined
-    showZoomHint.value = false
+    hideZoomHint()
     nextTick(() => initializeViewport(id))
   }
 
@@ -98,25 +130,20 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   }, { flush: 'sync' })
 
   function refreshViewportOrigin() {
-    if (!isActive.value) return
+    if (!interactionActive.value || !browserWindow) return
     const id = lifecycleId
     clearScheduledViewportWork()
-    refreshRaf1 = requestAnimationFrame(() => {
+    // Browser UI changes can move the fullscreen coordinate system across two frames.
+    refreshRaf1 = browserWindow.requestAnimationFrame(() => {
       refreshRaf1 = undefined
-      if (!isActive.value || id !== lifecycleId) return
-      refreshRaf2 = requestAnimationFrame(() => {
+      if (!interactionActive.value || id !== lifecycleId) return
+      refreshRaf2 = browserWindow.requestAnimationFrame(() => {
         refreshRaf2 = undefined
-        if (!isActive.value || id !== lifecycleId) return
-        const target = options.getRenderTarget()
+        if (!interactionActive.value || id !== lifecycleId) return
+        const target = renderTarget.value
         if (!target) return
         const rect = target.getBoundingClientRect()
-        zoom.setMetrics({
-          scale: zoom.scale.value,
-          translateX: zoom.translateX.value,
-          translateY: zoom.translateY.value,
-          top: rect.top,
-          left: rect.left,
-        })
+        zoom.setOrigin(rect.left, rect.top)
       })
     })
   }
@@ -128,6 +155,7 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   }
 
   function handleWheel(event: WheelEvent) {
+    if (!interactionActive.value) return
     if (zoom.handleWheel(event)) {
       if (showZoomHint.value) hideZoomHint()
       return
@@ -140,7 +168,7 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
     hintTimeout = setTimeout(() => {
       showZoomHint.value = false
       hintTimeout = undefined
-    }, hintDurationMs)
+    }, FULLSCREEN_ZOOM_HINT_DURATION_MS)
   }
 
   function isEditableTarget(target: EventTarget | null) {
@@ -154,6 +182,7 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    if (!interactionActive.value) return
     if (event.defaultPrevented || isEditableTarget(event.target)) return
 
     const browserZoomKeys = new Set(['+', '=', '-', '_'])
@@ -169,10 +198,10 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
       '-': zoom.zoomOut,
       '_': zoom.zoomOut,
       '0': zoom.reset,
-      'ArrowUp': () => { zoom.translateY.value += moveStep },
-      'ArrowDown': () => { zoom.translateY.value -= moveStep },
-      'ArrowLeft': () => { zoom.translateX.value += moveStep },
-      'ArrowRight': () => { zoom.translateX.value -= moveStep },
+      'ArrowUp': () => zoom.panBy(0, moveStep),
+      'ArrowDown': () => zoom.panBy(0, -moveStep),
+      'ArrowLeft': () => zoom.panBy(moveStep, 0),
+      'ArrowRight': () => zoom.panBy(-moveStep, 0),
     }
     const handler = keyHandlers[event.key]
     if (!handler) return
@@ -181,10 +210,10 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   }
 
   if (browserDocument && browserWindow) {
-    const activeWindow = computed(() => isActive.value ? browserWindow : null)
-    const activeDocument = computed(() => isActive.value ? browserDocument : null)
-    const activeVisualViewport = computed(() => isActive.value ? browserWindow.visualViewport : null)
-    const activeViewport = computed(() => isActive.value ? options.getViewportTarget() : null)
+    const activeWindow = computed(() => interactionActive.value ? browserWindow : null)
+    const activeDocument = computed(() => interactionActive.value ? browserDocument : null)
+    const activeVisualViewport = computed(() => interactionActive.value ? browserWindow.visualViewport : null)
+    const activeViewport = computed(() => interactionActive.value ? options.getViewportTarget() : null)
 
     useEventListener(activeWindow, 'wheel', handleWheel, { passive: false })
     useEventListener(activeDocument, 'keydown', handleKeyDown)
@@ -194,11 +223,11 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
     useEventListener(activeDocument, 'visibilitychange', () => {
       if (browserDocument.visibilityState === 'visible') refreshViewportOrigin()
     })
-    useEventListener(activeViewport, 'mousedown', zoom.handleDragStart)
-    useEventListener(activeViewport, 'mousemove', zoom.handleDragMove)
-    useEventListener(activeViewport, 'touchstart', zoom.handleDragStart)
-    useEventListener(activeViewport, 'touchmove', zoom.handleDragMove)
-    useEventListener(activeViewport, 'touchend', zoom.handleDragEnd)
+    useEventListener(activeViewport, 'mousedown', event => interactionActive.value && zoom.handleDragStart(event))
+    useEventListener(activeViewport, 'mousemove', event => interactionActive.value && zoom.handleDragMove(event))
+    useEventListener(activeViewport, 'touchstart', event => interactionActive.value && zoom.handleDragStart(event))
+    useEventListener(activeViewport, 'touchmove', event => interactionActive.value && zoom.handleDragMove(event))
+    useEventListener(activeViewport, 'touchend', () => interactionActive.value && zoom.handleDragEnd())
   }
 
   async function toggle() {
@@ -218,7 +247,6 @@ export function useMermaidFullscreen(options: UseMermaidFullscreenOptions) {
   return {
     isSupported: fullscreen.isSupported,
     isActive,
-    targetStyle,
     scale: computed(() => zoom.scale.value),
     showZoomHint,
     toggle,

--- a/src/runtime/composables/useMermaidZoom.ts
+++ b/src/runtime/composables/useMermaidZoom.ts
@@ -184,6 +184,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     })
 
     useEventListener(activeDocument, 'keydown', (e: KeyboardEvent) => {
+      if (!active.value) return
       if (e.code === 'Space') {
         if (e.repeat) return
         // Prevent default to stop scrolling when in modal
@@ -195,6 +196,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     })
 
     useEventListener(activeDocument, 'keyup', (e: KeyboardEvent) => {
+      if (!active.value) return
       if (e.code === 'Space') {
         e.preventDefault()
         isSpacePressed.value = false
@@ -205,14 +207,17 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
 
     // Global pointer up to catch releases outside the overlay
     useEventListener(activeWindow, 'pointerup', () => {
+      if (!active.value) return
       endInteraction()
     })
 
     useEventListener(activeWindow, 'pointercancel', () => {
+      if (!active.value) return
       endInteraction()
     })
 
     useEventListener(activeWindow, 'blur', () => {
+      if (!active.value) return
       if (isSpacePressed.value) {
         isSpacePressed.value = false
         unlockUserSelect()
@@ -224,6 +229,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   // --- Event Handlers ---
 
   function handleWheel(event: WheelEvent): boolean {
+    if (!active.value) return false
     // Only Zoom if Ctrl/Meta is pressed
     if (!event.ctrlKey && !event.metaKey) return false
 
@@ -253,6 +259,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   }
 
   function handleDragStart(event: MouseEvent | TouchEvent) {
+    if (!active.value) return
     const isTouch = 'touches' in event
 
     // Reset interaction state at the start of any potential gesture
@@ -294,6 +301,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   }
 
   function handleDragMove(event: MouseEvent | TouchEvent) {
+    if (!active.value) return
     if (!isPointerDown.value) return
 
     const isTouch = 'touches' in event
@@ -348,6 +356,7 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   }
 
   function handleDragEnd() {
+    if (!active.value) return
     isPointerDown.value = false
     lastPinchDist = -1
 

--- a/src/runtime/composables/useMermaidZoom.ts
+++ b/src/runtime/composables/useMermaidZoom.ts
@@ -1,4 +1,5 @@
 import { computed, ref, watch, type Ref } from 'vue'
+import type { ConfigurableDocument, ConfigurableWindow } from './_configurable'
 import { useEventListener } from './useEventListener'
 
 export interface ZoomMetrics {
@@ -9,7 +10,7 @@ export interface ZoomMetrics {
   left?: number
 }
 
-export interface UseMermaidZoomOptions {
+export interface UseMermaidZoomOptions extends ConfigurableDocument, ConfigurableWindow {
   active?: Ref<boolean>
   minScale?: number
   maxScale?: number
@@ -17,9 +18,11 @@ export interface UseMermaidZoomOptions {
 }
 
 export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
-  const isClient = typeof import.meta.client === 'boolean'
-    ? import.meta.client
-    : typeof window !== 'undefined' && typeof document !== 'undefined'
+  const browserDocument = options.document
+    ?? (typeof document === 'undefined' ? undefined : document)
+  const browserWindow = options.window
+    ?? (typeof window === 'undefined' ? undefined : window)
+  const isClient = !!browserDocument && !!browserWindow
   const {
     active = ref(true),
     minScale = 0.5,
@@ -68,20 +71,20 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
   })
 
   function lockUserSelect() {
-    if (!isClient) return
+    if (!browserDocument) return
     if (userSelectState.locked) return
-    userSelectState.html = document.documentElement.style.userSelect
-    userSelectState.body = document.body.style.userSelect
-    document.documentElement.style.userSelect = 'none'
-    document.body.style.userSelect = 'none'
+    userSelectState.html = browserDocument.documentElement.style.userSelect
+    userSelectState.body = browserDocument.body.style.userSelect
+    browserDocument.documentElement.style.userSelect = 'none'
+    browserDocument.body.style.userSelect = 'none'
     userSelectState.locked = true
   }
 
   function unlockUserSelect() {
-    if (!isClient) return
+    if (!browserDocument) return
     if (!userSelectState.locked) return
-    document.documentElement.style.userSelect = userSelectState.html
-    document.body.style.userSelect = userSelectState.body
+    browserDocument.documentElement.style.userSelect = userSelectState.html
+    browserDocument.body.style.userSelect = userSelectState.body
     userSelectState.html = ''
     userSelectState.body = ''
     userSelectState.locked = false
@@ -116,9 +119,10 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     if (s === scale.value) return
 
     if (!center) {
+      if (!browserWindow) return
       // Zoom to center of viewport
-      const viewportWidth = window.innerWidth
-      const viewportHeight = window.innerHeight
+      const viewportWidth = browserWindow.innerWidth
+      const viewportHeight = browserWindow.innerHeight
       center = { x: viewportWidth / 2, y: viewportHeight / 2 }
     }
 
@@ -142,6 +146,15 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     zoomTo(scale.value * (1 - 0.25))
   }
 
+  function panBy(deltaX: number, deltaY: number) {
+    translateX.value += deltaX
+    translateY.value += deltaY
+  }
+
+  function setOrigin(left: number, top: number) {
+    origin.value = { x: left, y: top }
+  }
+
   function endInteraction() {
     if (!isPointerDown.value && !isDragging.value) return
     handleDragEnd()
@@ -162,8 +175,8 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
 
   if (isClient) {
     // Elegant toggle: When active is false, target becomes null, listener is removed.
-    const activeDocument = computed(() => active.value ? document : null)
-    const activeWindow = computed(() => active.value ? window : null)
+    const activeDocument = computed(() => active.value ? browserDocument : null)
+    const activeWindow = computed(() => active.value ? browserWindow : null)
 
     watch(active, (isActive) => {
       if (isActive) return
@@ -357,6 +370,8 @@ export function useMermaidZoom(options: UseMermaidZoomOptions = {}) {
     reset,
     zoomIn,
     zoomOut,
+    panBy,
+    setOrigin,
     setMetrics,
     handleWheel,
     handleDragStart,

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -5,6 +5,7 @@ import type { ExpandOptions } from './types/expand'
 export const MERMAID_LOG_PREFIX = '[nuxt-content-mermaid]'
 export const DEFAULT_LIGHT_THEME: MermaidConfig['theme'] = 'default'
 export const DEFAULT_DARK_THEME: MermaidConfig['theme'] = 'dark'
+export const FULLSCREEN_ZOOM_HINT_DURATION_MS = 3000
 export const DEFAULT_MERMAID_CONFIG: MermaidConfig = {
   startOnLoad: false,
   theme: 'default',

--- a/test/expandToolbar.e2e.test.ts
+++ b/test/expandToolbar.e2e.test.ts
@@ -80,7 +80,7 @@ describe('expand/fullscreen toolbars', async () => {
 
     await page.waitForSelector('#mock-svg', { state: 'visible', timeout: 5000 })
 
-    await page.getByLabel('Expand diagram').click()
+    await page.locator('#diagram-root').getByLabel('Expand diagram').click()
     await page.waitForSelector('.ncm-expand-modal', { state: 'visible', timeout: 5000 })
 
     expect(await page.locator('body > .ncm-expand-modal').count()).toBe(1)
@@ -174,15 +174,18 @@ describe('expand/fullscreen toolbars', async () => {
     expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
   })
 
-  it('toggles fullscreen toolbar, zooms, and shows hint', { timeout: 20000 }, async () => {
+  it('proves the complete fullscreen lifecycle and cleanup through the Package User path', { timeout: 20000 }, async () => {
     const page = await createPage()
     await installFullscreenStub(page)
     await page.goto(url('/'))
     await page.waitForSelector('#mock-svg', { state: 'visible', timeout: 5000 })
 
-    await page.getByLabel('Enter fullscreen').click({ timeout: 5000 })
+    await page.locator('#diagram-root').getByLabel('Enter fullscreen').click({ timeout: 5000 })
     await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
     expect(await page.locator('.ncm-fullscreen-zoom-hint').count()).toBe(0)
+    expect(await page.locator('#diagram-root .mermaid-block > .ncm-zoom-toolbar--fullscreen').count()).toBe(1)
+    expect(await page.locator('#diagram-root .mermaid-wrapper.ncm-fullscreen-zoom > .mermaid').count()).toBe(1)
+    expect(await page.evaluate(() => document.fullscreenElement?.classList.contains('mermaid-block'))).toBe(true)
 
     const fullscreenZoomInfo = page.locator('.ncm-zoom-toolbar--fullscreen .ncm-zoom-info')
     const initialFullscreenPercent = parsePercent(await fullscreenZoomInfo.textContent())
@@ -195,14 +198,82 @@ describe('expand/fullscreen toolbars', async () => {
     expect(afterFullscreenPercent).toBeGreaterThan(initialFullscreenPercent)
 
     await page.evaluate(() => {
-      window.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }))
+      window.dispatchEvent(new Event('focus'))
+      window.visualViewport?.dispatchEvent(new Event('resize'))
+      return new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
     })
+    expect(parsePercent(await fullscreenZoomInfo.textContent())).toBe(afterFullscreenPercent)
+
+    const activeRouting = await page.evaluate(() => {
+      const wheel = new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true })
+      const key = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      window.dispatchEvent(wheel)
+      document.dispatchEvent(key)
+      return { wheel: wheel.defaultPrevented, key: key.defaultPrevented }
+    })
+    expect(activeRouting).toEqual({ wheel: false, key: true })
     await page.waitForSelector('.ncm-fullscreen-zoom-hint', { state: 'attached', timeout: 2000 })
     const hintText = await page.locator('.ncm-fullscreen-zoom-hint').textContent()
     expect(hintText).toContain('Scroll to zoom')
 
-    await page.getByLabel('Exit fullscreen').click({ timeout: 5000 })
+    const spaceLocked = await page.evaluate(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true }))
+      document.querySelector('.mermaid-wrapper')
+        ?.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true, cancelable: true }))
+      return {
+        body: document.body.style.userSelect,
+        html: document.documentElement.style.userSelect,
+      }
+    })
+    expect(spaceLocked).toEqual({ body: 'none', html: 'none' })
+
+    await page.locator('#diagram-root').getByLabel('Exit fullscreen').click({ timeout: 5000 })
     await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'detached', timeout: 5000 })
-    await page.close()
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
+    expect(await readPageStyles(page)).toEqual(restoredPageStyles)
+
+    await page.locator('#diagram-root').getByLabel('Enter fullscreen').click({ timeout: 5000 })
+    await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
+    await page.evaluate(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true }))
+      document.querySelector<HTMLButtonElement>('#unmount-diagram')?.click()
+    })
+    await page.waitForSelector('#diagram-root', { state: 'detached', timeout: 5000 })
+    await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'detached', timeout: 5000 })
+    expect(await page.evaluate(() => document.fullscreenElement)).toBeNull()
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
+    expect(await readPageStyles(page)).toEqual(restoredPageStyles)
+  })
+
+  it('ends fullscreen on render replacement and keeps diagrams isolated', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await installFullscreenStub(page)
+    await page.goto(url('/'))
+    await page.waitForSelector('#mock-svg-secondary', { state: 'visible', timeout: 5000 })
+
+    await page.locator('#diagram-root').getByLabel('Enter fullscreen').click({ timeout: 5000 })
+    await page.waitForSelector('#diagram-root .ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
+    expect(await page.locator('#secondary-root .ncm-zoom-toolbar--fullscreen').count()).toBe(0)
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }))
+      document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true }))
+      document.querySelector<HTMLButtonElement>('#update-diagram')?.click()
+    })
+
+    await page.waitForSelector('#diagram-root .ncm-zoom-toolbar--fullscreen', { state: 'detached', timeout: 5000 })
+    expect(await page.evaluate(() => document.fullscreenElement)).toBeNull()
+    expect(await page.locator('#secondary-root #mock-svg-secondary').count()).toBe(1)
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
+    expect(await readPageStyles(page)).toEqual(restoredPageStyles)
+
+    await page.locator('#secondary-root').getByLabel('Enter fullscreen').click({ timeout: 5000 })
+    await page.waitForSelector('#secondary-root .ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
+    expect(await page.locator('#diagram-root .ncm-zoom-toolbar--fullscreen').count()).toBe(0)
+    expect(await page.evaluate(() => document.fullscreenElement?.closest('#secondary-root') !== null)).toBe(true)
+
+    await page.locator('#secondary-root').getByLabel('Exit fullscreen').click({ timeout: 5000 })
+    await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'detached', timeout: 5000 })
+    expect(await readOutsideRouting(page)).toEqual({ wheel: false, key: false })
   })
 })

--- a/test/expandToolbar.e2e.test.ts
+++ b/test/expandToolbar.e2e.test.ts
@@ -251,6 +251,19 @@ describe('expand/fullscreen toolbars', async () => {
     await page.goto(url('/'))
     await page.waitForSelector('#mock-svg-secondary', { state: 'visible', timeout: 5000 })
 
+    await page.locator('#diagram-root').getByLabel('Expand diagram').click()
+    await page.waitForSelector('.ncm-expand-modal', { state: 'visible', timeout: 5000 })
+    await page.evaluate(() => {
+      document.querySelector<HTMLButtonElement>('#diagram-root [aria-label="Enter fullscreen"]')?.click()
+    })
+    await page.waitForSelector('#diagram-root .ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
+    await page.waitForSelector('.ncm-expand-modal', { state: 'detached', timeout: 5000 })
+    await page.locator('#mock-svg').click()
+    expect(await page.locator('.ncm-expand-modal').count()).toBe(0)
+    expect(await page.locator('#diagram-root [aria-label="Expand diagram"]').count()).toBe(0)
+    await page.locator('#diagram-root').getByLabel('Exit fullscreen').click({ timeout: 5000 })
+    await page.waitForSelector('.ncm-zoom-toolbar--fullscreen', { state: 'detached', timeout: 5000 })
+
     await page.locator('#diagram-root').getByLabel('Enter fullscreen').click({ timeout: 5000 })
     await page.waitForSelector('#diagram-root .ncm-zoom-toolbar--fullscreen', { state: 'visible', timeout: 5000 })
     expect(await page.locator('#secondary-root .ncm-zoom-toolbar--fullscreen').count()).toBe(0)

--- a/test/fixtures/expand-toolbar/app.vue
+++ b/test/fixtures/expand-toolbar/app.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
-const code = 'graph TD;A-->B;B-->C;'
-const encoded = computed(() => encodeURIComponent(code))
+const diagramVersion = ref(0)
+const code = computed(() => `graph TD;PRIMARY_${diagramVersion.value}-->B;B-->C;`)
+const secondaryCode = 'graph TD;SECONDARY-->B;'
+const encoded = computed(() => encodeURIComponent(code.value))
+const encodedSecondary = computed(() => encodeURIComponent(secondaryCode))
 const showDiagram = ref(true)
 </script>
 
 <template>
+  <button
+    id="update-diagram"
+    type="button"
+    @click="diagramVersion++"
+  >
+    Update diagram
+  </button>
   <button
     id="unmount-diagram"
     type="button"
@@ -19,5 +29,8 @@ const showDiagram = ref(true)
     id="diagram-root"
   >
     <Mermaid :code="encoded" />
+  </div>
+  <div id="secondary-root">
+    <Mermaid :code="encodedSecondary" />
   </div>
 </template>

--- a/test/fixtures/expand-toolbar/mermaid-stub.ts
+++ b/test/fixtures/expand-toolbar/mermaid-stub.ts
@@ -19,7 +19,8 @@ const mermaidStub = {
     const source = container.textContent || ''
     runs.push({ source })
 
-    container.innerHTML = '<svg id="mock-svg" width="600" height="400"></svg>'
+    const id = source.includes('SECONDARY') ? 'mock-svg-secondary' : 'mock-svg'
+    container.innerHTML = `<svg id="${id}" width="600" height="400"></svg>`
   },
 }
 

--- a/test/useMermaidFullscreen.test.ts
+++ b/test/useMermaidFullscreen.test.ts
@@ -237,10 +237,14 @@ describe('useMermaidFullscreen', () => {
         stopPropagation: vi.fn(),
       }
       const key = { key: 'ArrowDown', ctrlKey: false, metaKey: false, preventDefault: vi.fn() }
+      const space = { code: 'Space', repeat: false, preventDefault: vi.fn() }
       browser.windowTarget.dispatch('wheel', wheel)
       browser.documentTarget.dispatch('keydown', key)
+      browser.documentTarget.dispatch('keydown', space)
       expect(mounted.fullscreen.showZoomHint.value).toBe(false)
       expect(key.preventDefault).not.toHaveBeenCalled()
+      expect(space.preventDefault).not.toHaveBeenCalled()
+      expect(document.body.style.userSelect).toBe('text')
       await replacementEnd
     }
     else {

--- a/test/useMermaidFullscreen.test.ts
+++ b/test/useMermaidFullscreen.test.ts
@@ -42,11 +42,20 @@ function createBrowser() {
       documentTarget.dispatch('fullscreenchange')
     }),
   })
+  const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+    const id = ++rafId
+    rafs.set(id, callback)
+    rafHistory.push(callback)
+    return id
+  })
+  const cancelFrame = vi.fn((id: number) => rafs.delete(id))
   const windowTarget = createEventTarget({
     innerWidth: 1000,
     innerHeight: 800,
     visualViewport,
     document: documentTarget,
+    requestAnimationFrame: requestFrame,
+    cancelAnimationFrame: cancelFrame,
   })
   const fullscreenTarget = createEventTarget({
     nodeType: 1,
@@ -60,18 +69,14 @@ function createBrowser() {
   let renderRect = { top: 20, left: 30, width: 200, height: 100 }
   const renderTarget = {
     nodeType: 1,
+    style: { transform: '', transformOrigin: '', cursor: '' },
     getBoundingClientRect: () => renderRect,
   }
 
   vi.stubGlobal('document', documentTarget)
   vi.stubGlobal('window', windowTarget)
-  vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
-    const id = ++rafId
-    rafs.set(id, callback)
-    rafHistory.push(callback)
-    return id
-  }))
-  vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => rafs.delete(id)))
+  vi.stubGlobal('requestAnimationFrame', requestFrame)
+  vi.stubGlobal('cancelAnimationFrame', cancelFrame)
 
   return {
     documentTarget,
@@ -155,7 +160,7 @@ describe('useMermaidFullscreen', () => {
     await enterFullscreen(fullscreen)
 
     expect(fullscreen.isActive.value).toBe(true)
-    expect(fullscreen.targetStyle.value.transform).toBe('translate(0px, 0px) scale(1)')
+    expect(browser.renderTarget.style.transform).toBe('translate(0px, 0px) scale(1)')
     expect(browser.windowTarget.listenerCount('wheel')).toBe(1)
     expect(browser.documentTarget.listenerCount('keydown')).toBeGreaterThan(0)
 
@@ -187,7 +192,7 @@ describe('useMermaidFullscreen', () => {
     const arrow = { key: 'ArrowRight', ctrlKey: false, metaKey: false, preventDefault: vi.fn() }
     browser.documentTarget.dispatch('keydown', arrow)
     expect(arrow.preventDefault).toHaveBeenCalled()
-    expect(fullscreen.targetStyle.value.transform).not.toContain('translate(0px, 0px)')
+    expect(browser.renderTarget.style.transform).not.toContain('translate(0px, 0px)')
 
     browser.documentTarget.dispatch('keydown', { code: 'Space', repeat: false, preventDefault: vi.fn() })
     browser.viewportTarget.dispatch('mousedown', { clientX: 10, clientY: 10, preventDefault: vi.fn() })
@@ -219,9 +224,28 @@ describe('useMermaidFullscreen', () => {
     browser.windowTarget.dispatch('focus')
     const staleFrame = browser.rafHistory.at(-1)
 
-    if (ending === 'exit') await mounted.fullscreen.toggle()
-    else if (ending === 'replacement') await mounted.fullscreen.endForDiagramReplacement()
-    else mounted.unmount()
+    if (ending === 'exit') {
+      await mounted.fullscreen.toggle()
+    }
+    else if (ending === 'replacement') {
+      const replacementEnd = mounted.fullscreen.endForDiagramReplacement()
+      const wheel = {
+        deltaY: 120,
+        ctrlKey: false,
+        metaKey: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      }
+      const key = { key: 'ArrowDown', ctrlKey: false, metaKey: false, preventDefault: vi.fn() }
+      browser.windowTarget.dispatch('wheel', wheel)
+      browser.documentTarget.dispatch('keydown', key)
+      expect(mounted.fullscreen.showZoomHint.value).toBe(false)
+      expect(key.preventDefault).not.toHaveBeenCalled()
+      await replacementEnd
+    }
+    else {
+      mounted.unmount()
+    }
     await nextTick()
 
     expect(mounted.fullscreen.isActive.value).toBe(false)
@@ -235,7 +259,7 @@ describe('useMermaidFullscreen', () => {
     browser.flushRafs()
     staleFrame?.(0)
     expect(mounted.fullscreen.isActive.value).toBe(false)
-    expect(mounted.fullscreen.targetStyle.value.transform).toBe('translate(0px, 0px) scale(1)')
+    expect(browser.renderTarget.style).toMatchObject({ transform: '', transformOrigin: '', cursor: '' })
   })
 
   it('keeps inactive diagrams isolated from fullscreen routing', async () => {

--- a/test/useMermaidFullscreen.test.ts
+++ b/test/useMermaidFullscreen.test.ts
@@ -1,0 +1,257 @@
+import { createRenderer, defineComponent, h, nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useMermaidFullscreen } from '../src/runtime/composables/useMermaidFullscreen'
+
+type Listener = (event: Event) => void
+
+function createEventTarget<T extends Record<string, unknown>>(extra: T = {} as T) {
+  const listeners = new Map<string, Set<Listener>>()
+  return {
+    ...extra,
+    addEventListener: vi.fn((type: string, listener: Listener) => {
+      const handlers = listeners.get(type) ?? new Set<Listener>()
+      handlers.add(listener)
+      listeners.set(type, handlers)
+    }),
+    removeEventListener: vi.fn((type: string, listener: Listener) => listeners.get(type)?.delete(listener)),
+    dispatch(type: string, event: Record<string, unknown> = {}) {
+      for (const listener of listeners.get(type) ?? []) listener(event as unknown as Event)
+    },
+    listenerCount(type: string) {
+      return listeners.get(type)?.size ?? 0
+    },
+  }
+}
+
+function createBrowser() {
+  let rafId = 0
+  const rafs = new Map<number, FrameRequestCallback>()
+  const rafHistory: FrameRequestCallback[] = []
+  const visualViewport = createEventTarget({ width: 1000, height: 800, scale: 1 })
+  const documentElement = { style: { userSelect: 'text' } }
+  const body = { style: { userSelect: 'text' } }
+  const documentTarget = createEventTarget({
+    body,
+    documentElement,
+    fullScreen: false,
+    fullscreenElement: null as unknown,
+    visibilityState: 'visible',
+    exitFullscreen: vi.fn(async () => {
+      documentTarget.fullScreen = false
+      documentTarget.fullscreenElement = null
+      documentTarget.dispatch('fullscreenchange')
+    }),
+  })
+  const windowTarget = createEventTarget({
+    innerWidth: 1000,
+    innerHeight: 800,
+    visualViewport,
+    document: documentTarget,
+  })
+  const fullscreenTarget = createEventTarget({
+    nodeType: 1,
+    requestFullscreen: vi.fn(async () => {
+      documentTarget.fullScreen = true
+      documentTarget.fullscreenElement = fullscreenTarget
+      documentTarget.dispatch('fullscreenchange')
+    }),
+  })
+  const viewportTarget = createEventTarget({ nodeType: 1 })
+  let renderRect = { top: 20, left: 30, width: 200, height: 100 }
+  const renderTarget = {
+    nodeType: 1,
+    getBoundingClientRect: () => renderRect,
+  }
+
+  vi.stubGlobal('document', documentTarget)
+  vi.stubGlobal('window', windowTarget)
+  vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+    const id = ++rafId
+    rafs.set(id, callback)
+    rafHistory.push(callback)
+    return id
+  }))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => rafs.delete(id)))
+
+  return {
+    documentTarget,
+    windowTarget,
+    visualViewport,
+    fullscreenTarget,
+    viewportTarget,
+    renderTarget,
+    rafHistory,
+    setRenderRect(rect: typeof renderRect) {
+      renderRect = rect
+    },
+    flushRafs() {
+      const pending = [...rafs.entries()]
+      rafs.clear()
+      pending.forEach(([, callback]) => callback(0))
+    },
+  }
+}
+
+const renderer = createRenderer<Record<string, unknown>, Record<string, unknown>>({
+  patchProp: () => {},
+  insert: () => {},
+  remove: () => {},
+  createElement: () => ({}),
+  createText: () => ({}),
+  createComment: () => ({}),
+  setText: () => {},
+  setElementText: () => {},
+  parentNode: () => null,
+  nextSibling: () => null,
+  querySelector: () => null,
+  setScopeId: () => {},
+  cloneNode: node => node,
+  insertStaticContent: () => [{}, {}],
+})
+
+function mountFullscreen(browser: ReturnType<typeof createBrowser>) {
+  let fullscreen: ReturnType<typeof useMermaidFullscreen> | undefined
+  const app = renderer.createApp(defineComponent({
+    setup() {
+      fullscreen = useMermaidFullscreen({
+        getFullscreenTarget: () => browser.fullscreenTarget as unknown as HTMLElement,
+        getViewportTarget: () => browser.viewportTarget as unknown as HTMLElement,
+        getRenderTarget: () => browser.renderTarget as unknown as HTMLElement,
+        document: browser.documentTarget as unknown as Document,
+        window: browser.windowTarget as unknown as Window,
+      })
+      return () => h('div')
+    },
+  }))
+  app.mount({})
+
+  return {
+    fullscreen: fullscreen!,
+    unmount: () => app.unmount(),
+  }
+}
+
+async function enterFullscreen(fullscreen: ReturnType<typeof useMermaidFullscreen>) {
+  await fullscreen.toggle()
+  await nextTick()
+}
+
+describe('useMermaidFullscreen', () => {
+  let browser: ReturnType<typeof createBrowser>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    browser = createBrowser()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('owns entry, viewport controls, interaction routing and exit cleanup', async () => {
+    const { fullscreen } = mountFullscreen(browser)
+
+    await enterFullscreen(fullscreen)
+
+    expect(fullscreen.isActive.value).toBe(true)
+    expect(fullscreen.targetStyle.value.transform).toBe('translate(0px, 0px) scale(1)')
+    expect(browser.windowTarget.listenerCount('wheel')).toBe(1)
+    expect(browser.documentTarget.listenerCount('keydown')).toBeGreaterThan(0)
+
+    fullscreen.zoomIn()
+    expect(fullscreen.scale.value).toBe(1.25)
+
+    browser.windowTarget.dispatch('wheel', {
+      deltaY: 120,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    })
+    expect(fullscreen.showZoomHint.value).toBe(true)
+
+    const zoomWheel = {
+      deltaY: -120,
+      clientX: 100,
+      clientY: 100,
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    }
+    browser.windowTarget.dispatch('wheel', zoomWheel)
+    expect(zoomWheel.preventDefault).toHaveBeenCalled()
+    expect(fullscreen.showZoomHint.value).toBe(false)
+
+    const arrow = { key: 'ArrowRight', ctrlKey: false, metaKey: false, preventDefault: vi.fn() }
+    browser.documentTarget.dispatch('keydown', arrow)
+    expect(arrow.preventDefault).toHaveBeenCalled()
+    expect(fullscreen.targetStyle.value.transform).not.toContain('translate(0px, 0px)')
+
+    browser.documentTarget.dispatch('keydown', { code: 'Space', repeat: false, preventDefault: vi.fn() })
+    browser.viewportTarget.dispatch('mousedown', { clientX: 10, clientY: 10, preventDefault: vi.fn() })
+    expect(document.body.style.userSelect).toBe('none')
+
+    await fullscreen.toggle()
+    await nextTick()
+
+    expect(fullscreen.isActive.value).toBe(false)
+    expect(fullscreen.showZoomHint.value).toBe(false)
+    expect(document.body.style.userSelect).toBe('text')
+    expect(document.documentElement.style.userSelect).toBe('text')
+    expect(browser.windowTarget.listenerCount('wheel')).toBe(0)
+  })
+
+  it.each(['exit', 'replacement', 'unmount'])('cancels hint, gesture, scheduled viewport work and routing on %s', async (ending) => {
+    const mounted = mountFullscreen(browser)
+    await enterFullscreen(mounted.fullscreen)
+
+    browser.windowTarget.dispatch('wheel', {
+      deltaY: 120,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    })
+    browser.documentTarget.dispatch('keydown', { code: 'Space', repeat: false, preventDefault: vi.fn() })
+    browser.viewportTarget.dispatch('mousedown', { clientX: 10, clientY: 10, preventDefault: vi.fn() })
+    browser.windowTarget.dispatch('focus')
+    const staleFrame = browser.rafHistory.at(-1)
+
+    if (ending === 'exit') await mounted.fullscreen.toggle()
+    else if (ending === 'replacement') await mounted.fullscreen.endForDiagramReplacement()
+    else mounted.unmount()
+    await nextTick()
+
+    expect(mounted.fullscreen.isActive.value).toBe(false)
+    expect(mounted.fullscreen.showZoomHint.value).toBe(false)
+    expect(document.body.style.userSelect).toBe('text')
+    expect(browser.windowTarget.listenerCount('wheel')).toBe(0)
+    expect(browser.documentTarget.listenerCount('keydown')).toBe(0)
+    expect(cancelAnimationFrame).toHaveBeenCalled()
+
+    vi.runAllTimers()
+    browser.flushRafs()
+    staleFrame?.(0)
+    expect(mounted.fullscreen.isActive.value).toBe(false)
+    expect(mounted.fullscreen.targetStyle.value.transform).toBe('translate(0px, 0px) scale(1)')
+  })
+
+  it('keeps inactive diagrams isolated from fullscreen routing', async () => {
+    const first = mountFullscreen(browser)
+    const secondBrowser = createBrowser()
+    const second = mountFullscreen(secondBrowser)
+
+    await enterFullscreen(first.fullscreen)
+    first.fullscreen.zoomIn()
+
+    expect(first.fullscreen.scale.value).toBe(1.25)
+    expect(second.fullscreen.isActive.value).toBe(false)
+    expect(second.fullscreen.scale.value).toBe(1)
+    expect(secondBrowser.windowTarget.listenerCount('wheel')).toBe(0)
+
+    first.unmount()
+    second.unmount()
+  })
+})

--- a/test/useMermaidZoom.test.ts
+++ b/test/useMermaidZoom.test.ts
@@ -109,6 +109,32 @@ describe('useMermaidZoom', () => {
     expect(zoom.scale.value).toBe(0.9)
   })
 
+  it('uses the configured browser instance for viewport mechanics', () => {
+    const injectedDocument = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      documentElement: { style: { userSelect: '' } },
+      body: { style: { userSelect: '' } },
+    }
+    const injectedWindow = {
+      innerWidth: 400,
+      innerHeight: 200,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      document: injectedDocument,
+    }
+    const zoom = useMermaidZoom({
+      document: injectedDocument as unknown as Document,
+      window: injectedWindow as unknown as Window,
+    })
+    zoom.init({ scale: 1, translateX: 0, translateY: 0, top: 0, left: 0 })
+
+    zoom.zoomIn()
+
+    expect(zoom.translateX.value).toBe(-50)
+    expect(zoom.translateY.value).toBe(-25)
+  })
+
   it('handleWheel requires modifier and updates scale', () => {
     const zoom = useMermaidZoom({ zoomSpeed: 0.2 })
     zoom.init({ scale: 1, translateX: 0, translateY: 0, top: 0, left: 0 })


### PR DESCRIPTION
## Summary

- move the complete browser fullscreen and inspection lifecycle into useMermaidFullscreen
- contract Mermaid.vue behind a dedicated fullscreen presentation boundary
- add lifecycle, transition, replacement, teardown, and multi-diagram isolation coverage

## Verification

- pnpm lint --fix
- pnpm test:types
- pnpm exec vitest run --dir test (17 files, 99 tests)
- pnpm prepack
- pnpm dev:build

Closes #18