### PR TITLE
feat!: define v3 configuration types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Playground prepare
         run: npm run dev:prepare
 
+      - name: Package contract
+        run: npm run test:package-contract
+
       - name: Install Playwright browsers
         run: npx playwright install
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "release": "pnpm run release:patch",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:package-contract": "pnpm prepack && vue-tsc -p test/package-contract/tsconfig.json --noEmit",
     "test:watch": "vitest watch",
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,6 @@ import {
 } from '@nuxt/kit'
 import { defu } from 'defu'
 import type { FileBeforeParseHook } from '@nuxt/content'
-import type { MermaidConfig } from 'mermaid'
 import {
   DEFAULT_DARK_THEME,
   DEFAULT_LIGHT_THEME,
@@ -18,9 +17,16 @@ import {
   DEFAULT_TOOLBAR_OPTIONS,
   DEFAULT_EXPAND_OPTIONS,
 } from './runtime/constants'
-import type { ExpandOptions } from './runtime/types/expand'
 import { transformMarkdownDiagrams } from './markdown-diagram-transform'
-import type { MermaidToolbarOptions } from './types/mermaid'
+import type { ModuleOptions, RuntimeMermaidConfig } from './types/config'
+
+export type {
+  MermaidComponentProps,
+  ModuleOptions,
+  PageMermaidConfig,
+  RuntimeMermaidConfig,
+  RuntimeOptions,
+} from './types/config'
 
 const MODULE_NAME = '@barzhsieh/nuxt-content-mermaid'
 
@@ -47,84 +53,10 @@ const MERMAID_OPTIMIZE_DEPS = [
   'dayjs/plugin/duration.js',
 ]
 
-export interface ModuleOptions {
-  /**
-   * Whether to enable the entire Mermaid process
-   * @default true
-   */
-  enabled?: boolean
-  /**
-   * Enable debug mode for detailed logging and error reporting
-   * @default false
-   */
-  debug?: boolean
-  /**
-   * Options related to loading mermaid
-   */
-  loader?: {
-    /**
-     * Pass-through to `mermaid.initialize`
-     */
-    init?: MermaidConfig
-    /**
-     * Whether to lazy load the diagram when it enters the viewport.
-     * Can be a boolean or an object with IntersectionObserver options.
-     * @default true
-     */
-    lazy?: boolean | { threshold?: number }
-  }
-  /**
-   * Options related to theme handling
-   */
-  theme?: {
-    /**
-     * @deprecated The module now automatically detects and syncs with @nuxtjs/color-mode.
-     * This option no longer has any effect and will be removed in a future version.
-     */
-    useColorModeTheme?: boolean
-    light?: MermaidConfig['theme']
-    dark?: MermaidConfig['theme']
-  }
-  /**
-   * Names for custom implementation components
-   */
-  components?: {
-    /**
-     * Custom Mermaid implementation component name (e.g., 'MyMermaid').
-     * The Markdown transformation phase always outputs `<Mermaid>`, this setting only affects
-     * which component implementation `Mermaid.vue` delegates to at runtime.
-     */
-    renderer?: string
-    /**
-     * Spinner component name to use while Mermaid is loading.
-     * This should be a globally available component name (e.g., under the project `components/` directory).
-     * If not provided, the module's built-in `Spinner.vue` will be used.
-     */
-    spinner?: string
-    /**
-     * Error component name to display when Mermaid rendering fails.
-     * This should be a globally available component name (e.g., under the project `components/` directory).
-     * If not provided, the module's built-in fallback message will be used.
-     */
-    error?: string
-  }
-  /**
-   * Options related to SVG expand (lightbox) interactions
-   */
-  /**
-   * Expand configuration. `false` disables expand, `true` uses defaults.
-   */
-  expand?: ExpandOptions | boolean
-  /**
-   * Default toolbar settings for Mermaid component
-   */
-  toolbar?: MermaidToolbarOptions
-}
-
 const DEFAULTS = {
   enabled: true,
   loader: {
-    init: { ...DEFAULT_MERMAID_CONFIG },
+    init: { ...DEFAULT_MERMAID_CONFIG } as RuntimeMermaidConfig,
     lazy: true,
   },
   theme: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,7 +4,7 @@ import type { MermaidToolbarOptions } from './mermaid'
 
 export type JsonPrimitive = string | number | boolean | null
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[]
-export type JsonObject = { [key: string]: JsonValue | undefined }
+export type JsonObject = { [key: string]: JsonValue }
 
 type IsAny<T> = 0 extends (1 & T) ? true : false
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,90 @@
+import type { MermaidConfig } from 'mermaid'
+import type { ExpandOptions } from '../runtime/types/expand'
+import type { MermaidToolbarOptions } from './mermaid'
+
+export type JsonPrimitive = string | number | boolean | null
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[]
+export type JsonObject = { [key: string]: JsonValue | undefined }
+
+type IsAny<T> = 0 extends (1 & T) ? true : false
+
+type RuntimeDataMember<T> = IsAny<T> extends true
+  ? never
+  : T extends JsonPrimitive
+    ? T
+    : T extends (...args: never[]) => unknown
+      ? never
+      : T extends readonly (infer Item)[]
+        ? RuntimeDataMember<Item>[]
+        : T extends object
+          ? { [Key in keyof T]: RuntimeDataMember<T[Key]> }
+          : never
+
+export type RuntimeMermaidConfig = RuntimeDataMember<MermaidConfig> & JsonObject
+export type PageMermaidConfig = RuntimeMermaidConfig
+
+export interface RuntimeOptions {
+  /**
+   * Enable debug mode for detailed logging and error reporting
+   * @default false
+   */
+  debug?: boolean
+  /**
+   * Options related to loading mermaid
+   */
+  loader?: {
+    /**
+     * Pure-data configuration passed through Nuxt public runtime config.
+     */
+    init?: RuntimeMermaidConfig
+    /**
+     * Whether to lazy load the diagram when it enters the viewport.
+     * Can be a boolean or an object with IntersectionObserver options.
+     * @default true
+     */
+    lazy?: boolean | { threshold?: number }
+  }
+  /**
+   * Options related to theme handling
+   */
+  theme?: {
+    /** @deprecated No effect; retained for 3.0 compatibility. */
+    useColorModeTheme?: boolean
+    light?: MermaidConfig['theme']
+    dark?: MermaidConfig['theme']
+  }
+  /**
+   * Names for custom implementation components
+   */
+  components?: {
+    renderer?: string
+    spinner?: string
+    error?: string
+  }
+  /**
+   * Expand configuration. `false` disables expand, `true` uses defaults.
+   */
+  expand?: ExpandOptions | boolean
+  /**
+   * Default toolbar settings for Mermaid component
+   */
+  toolbar?: MermaidToolbarOptions
+}
+
+export interface ModuleOptions extends RuntimeOptions {
+  /**
+   * Whether to enable the entire Mermaid process at build time.
+   * @default true
+   */
+  enabled?: boolean
+}
+
+interface MermaidComponentBaseProps {
+  toolbar?: MermaidToolbarOptions
+  code?: string
+}
+
+export type MermaidComponentProps = MermaidComponentBaseProps & (
+  | { pageConfig?: PageMermaidConfig, config?: never }
+  | { pageConfig?: never, config?: MermaidConfig }
+)

--- a/src/types/mermaid.d.ts
+++ b/src/types/mermaid.d.ts
@@ -1,6 +1,6 @@
 import type { DefineComponent } from 'vue'
-import type { Mermaid, MermaidConfig } from 'mermaid'
-import type { ModuleOptions } from '../module'
+import type { Mermaid } from 'mermaid'
+import type { MermaidComponentProps, ModuleOptions, RuntimeOptions } from './config'
 import type { MermaidThemeMode, SimpleMermaidTheme } from '../runtime/composables/useMermaidTheme'
 
 export type MermaidToolbarButtons = {
@@ -26,37 +26,21 @@ declare module 'vue' {
     $mermaid: () => Promise<Mermaid>
   }
   interface GlobalComponents {
-    Mermaid: DefineComponent<{
-      config?: MermaidConfig
-      toolbar?: MermaidToolbarOptions
-      code?: string
-    }>
+    Mermaid: DefineComponent<MermaidComponentProps>
   }
 }
 
 declare module 'nuxt/schema' {
   interface NuxtConfig {
     contentMermaid?: ModuleOptions
-    /**
-     * @deprecated Use `contentMermaid`
-     */
-    mermaidContent?: ModuleOptions
   }
 
   interface NuxtOptions {
     contentMermaid?: ModuleOptions
-    /**
-     * @deprecated Use `contentMermaid`
-     */
-    mermaidContent?: ModuleOptions
   }
 
   interface PublicRuntimeConfig {
-    contentMermaid?: Partial<ModuleOptions>
-    /**
-     * @deprecated Use `contentMermaid`
-     */
-    mermaidContent?: Partial<ModuleOptions>
+    contentMermaid?: RuntimeOptions
   }
 }
 

--- a/test/package-contract/tsconfig.json
+++ b/test/package-contract/tsconfig.json
@@ -5,6 +5,7 @@
   },
   "include": [
     "./package-user.ts",
-    "./removed-transform.ts"
+    "./removed-transform.ts",
+    "./v3-configuration.ts"
   ]
 }

--- a/test/package-contract/tsconfig.json
+++ b/test/package-contract/tsconfig.json
@@ -1,7 +1,14 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "./package-user.ts",

--- a/test/package-contract/v3-configuration.ts
+++ b/test/package-contract/v3-configuration.ts
@@ -1,0 +1,70 @@
+import type { NuxtConfig } from '@nuxt/schema'
+import type {
+  MermaidComponentProps,
+  ModuleOptions,
+  RuntimeMermaidConfig,
+  RuntimeOptions,
+} from '../../src/module'
+
+const runtimeConfig = {
+  debug: true,
+  loader: {
+    init: {
+      theme: 'dark',
+      unknownMermaidExtension: { enabled: false, values: [null, 1, 'kept'] },
+    },
+  },
+} satisfies RuntimeOptions
+
+const moduleConfig = {
+  enabled: false,
+  ...runtimeConfig,
+} satisfies ModuleOptions
+
+const pageProps = {
+  pageConfig: { theme: 'forest' },
+  code: 'graph TD; A-->B',
+} satisfies MermaidComponentProps
+
+const directProps = {
+  config: { sequence: { actorFont: () => ({ fontSize: 14 }) } },
+} satisfies MermaidComponentProps
+
+// @ts-expect-error runtime transport cannot contain functions
+const invalidRuntimeFunction: RuntimeMermaidConfig = { sequence: { actorFont: () => ({}) } }
+
+// @ts-expect-error recursively nested runtime values must remain pure data
+const invalidNestedRuntimeFunction: RuntimeMermaidConfig = { unknownMermaidExtension: { load: () => ({}) } }
+
+// @ts-expect-error runtime transport cannot contain arbitrary class instances
+const invalidRuntimeInstance: RuntimeMermaidConfig = { unknownMermaidExtension: new Date() }
+
+// @ts-expect-error Mermaid's unbounded `any` field is not part of the runtime transport contract
+const invalidRuntimeAny: RuntimeMermaidConfig = { themeVariables: {} }
+
+// @ts-expect-error build activation is not a runtime option
+const invalidRuntimeEnabled: RuntimeOptions = { enabled: false }
+
+// @ts-expect-error page configuration is pure data
+const invalidPageProps: MermaidComponentProps = { pageConfig: { sequence: { actorFont: () => ({}) } } }
+
+// @ts-expect-error configuration source props are mutually exclusive
+const invalidComponentProps: MermaidComponentProps = { pageConfig: {}, config: {} }
+
+declare const nuxtConfig: NuxtConfig
+
+// @ts-expect-error 3.0 removes the legacy Nuxt configuration alias
+void nuxtConfig.mermaidContent
+
+void [
+  moduleConfig,
+  pageProps,
+  directProps,
+  invalidRuntimeFunction,
+  invalidNestedRuntimeFunction,
+  invalidRuntimeInstance,
+  invalidRuntimeAny,
+  invalidRuntimeEnabled,
+  invalidPageProps,
+  invalidComponentProps,
+]

--- a/test/package-contract/v3-configuration.ts
+++ b/test/package-contract/v3-configuration.ts
@@ -4,7 +4,7 @@ import type {
   ModuleOptions,
   RuntimeMermaidConfig,
   RuntimeOptions,
-} from '../../src/module'
+} from '@barzhsieh/nuxt-content-mermaid'
 
 const runtimeConfig = {
   debug: true,
@@ -39,6 +39,9 @@ const invalidNestedRuntimeFunction: RuntimeMermaidConfig = { unknownMermaidExten
 // @ts-expect-error runtime transport cannot contain arbitrary class instances
 const invalidRuntimeInstance: RuntimeMermaidConfig = { unknownMermaidExtension: new Date() }
 
+// @ts-expect-error runtime transport cannot contain explicit undefined values
+const invalidRuntimeUndefined: RuntimeMermaidConfig = { unknownMermaidExtension: undefined }
+
 // @ts-expect-error Mermaid's unbounded `any` field is not part of the runtime transport contract
 const invalidRuntimeAny: RuntimeMermaidConfig = { themeVariables: {} }
 
@@ -63,6 +66,7 @@ void [
   invalidRuntimeFunction,
   invalidNestedRuntimeFunction,
   invalidRuntimeInstance,
+  invalidRuntimeUndefined,
   invalidRuntimeAny,
   invalidRuntimeEnabled,
   invalidPageProps,

--- a/test/package-contract/v3-configuration.ts
+++ b/test/package-contract/v3-configuration.ts
@@ -1,10 +1,15 @@
-import type { NuxtConfig } from '@nuxt/schema'
+import type { NuxtConfig, PublicRuntimeConfig } from '@nuxt/schema'
 import type {
   MermaidComponentProps,
   ModuleOptions,
   RuntimeMermaidConfig,
   RuntimeOptions,
 } from '@barzhsieh/nuxt-content-mermaid'
+
+type IsUnknown<T> = unknown extends T
+  ? keyof T extends never ? true : false
+  : false
+type Expect<T extends true> = T
 
 const runtimeConfig = {
   debug: true,
@@ -20,6 +25,10 @@ const moduleConfig = {
   enabled: false,
   ...runtimeConfig,
 } satisfies ModuleOptions
+
+const publicRuntimeConfig = {
+  contentMermaid: runtimeConfig,
+} satisfies PublicRuntimeConfig
 
 const pageProps = {
   pageConfig: { theme: 'forest' },
@@ -55,12 +64,21 @@ const invalidPageProps: MermaidComponentProps = { pageConfig: { sequence: { acto
 const invalidComponentProps: MermaidComponentProps = { pageConfig: {}, config: {} }
 
 declare const nuxtConfig: NuxtConfig
+declare const resolvedPublicRuntimeConfig: PublicRuntimeConfig
 
 // @ts-expect-error 3.0 removes the legacy Nuxt configuration alias
 void nuxtConfig.mermaidContent
 
+// @ts-expect-error module activation is absent from public runtime configuration
+void resolvedPublicRuntimeConfig.contentMermaid?.enabled
+
+type LegacyPublicRuntimeAliasIsUnclaimed = Expect<
+  IsUnknown<PublicRuntimeConfig['mermaidContent']>
+>
+
 void [
   moduleConfig,
+  publicRuntimeConfig,
   pageProps,
   directProps,
   invalidRuntimeFunction,
@@ -72,3 +90,5 @@ void [
   invalidPageProps,
   invalidComponentProps,
 ]
+
+export type { LegacyPublicRuntimeAliasIsUnclaimed }

--- a/test/packageContract.test.ts
+++ b/test/packageContract.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('package root runtime contract', () => {
@@ -6,5 +7,13 @@ describe('package root runtime contract', () => {
 
     expect(packageModule.default).toBeDefined()
     expect('transformMermaidCodeBlocks' in packageModule).toBe(false)
+  })
+
+  it('publishes the v3 configuration type contract', () => {
+    const declaration = readFileSync(new URL('../dist/module.d.mts', import.meta.url), 'utf8')
+
+    expect(declaration).toContain('interface RuntimeOptions')
+    expect(declaration).toContain('pageConfig')
+    expect(declaration).not.toContain('mermaidContent')
   })
 })

--- a/test/packageContract.test.ts
+++ b/test/packageContract.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('package root runtime contract', () => {
@@ -7,13 +6,5 @@ describe('package root runtime contract', () => {
 
     expect(packageModule.default).toBeDefined()
     expect('transformMermaidCodeBlocks' in packageModule).toBe(false)
-  })
-
-  it('publishes the v3 configuration type contract', () => {
-    const declaration = readFileSync(new URL('../dist/module.d.mts', import.meta.url), 'utf8')
-
-    expect(declaration).toContain('interface RuntimeOptions')
-    expect(declaration).toContain('pageConfig')
-    expect(declaration).not.toContain('mermaidContent')
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,6 @@
     "dist",
     "node_modules",
     "playground",
+    "test/package-contract",
   ],
 }


### PR DESCRIPTION
## Summary

- separate build-only `ModuleOptions` from pure-data `RuntimeOptions`
- add recursive strict JSON-data Runtime/Page Mermaid configuration types while preserving Direct Mermaid Config capabilities
- make `pageConfig` and `config` mutually exclusive component prop sources
- remove `mermaidContent` from the v3 ambient public contract
- add Package User accepted/rejected type regressions and built declaration assertions

Closes #22

## Validation

- `pnpm lint --fix`
- `pnpm exec vue-tsc -p test/package-contract/tsconfig.json --noEmit`
- `pnpm test:types`
- `pnpm prepack`
- `pnpm test` — 17 files, 100 tests passed

## Review

- Standards: 0 findings
- Spec: 2 findings found and fixed (`undefined` transport values; package-root type import), then re-reviewed with 0 remaining findings