### PR TITLE
feat: add descriptor-safe configuration core

### DIFF
--- a/src/configuration/core.ts
+++ b/src/configuration/core.ts
@@ -1,0 +1,478 @@
+import type { JsonObject, JsonValue } from '../types/config'
+
+export interface ConfigurationValidationPhase {
+  readonly name: string
+  readonly root: string
+}
+
+export type ConfigurationIssueCode
+  = | 'ACCESSOR_PROPERTY'
+    | 'ANCESTOR_CYCLE'
+    | 'ARRAY_PROPERTY'
+    | 'BIGINT_VALUE'
+    | 'FUNCTION_VALUE'
+    | 'NEGATIVE_ZERO'
+    | 'NON_ENUMERABLE_PROPERTY'
+    | 'NON_FINITE_NUMBER'
+    | 'NON_PLAIN_OBJECT'
+    | 'SPARSE_ARRAY_SLOT'
+    | 'SYMBOL_KEY'
+    | 'SYMBOL_VALUE'
+    | 'UNDEFINED_VALUE'
+
+export interface ConfigurationIssue {
+  readonly path: readonly (string | number)[]
+  readonly code: ConfigurationIssueCode
+  readonly expected: string
+  readonly received: string
+}
+
+function formatPath(root: string, path: readonly (string | number)[]): string {
+  return path.reduce<string>((formatted, segment) => {
+    if (typeof segment === 'number') return `${formatted}[${segment}]`
+
+    return /^[A-Z_$][\w$]*$/i.test(segment)
+      ? `${formatted}.${segment}`
+      : `${formatted}[${JSON.stringify(segment)}]`
+  }, root)
+}
+
+function createMessage(
+  phase: ConfigurationValidationPhase,
+  issues: readonly ConfigurationIssue[],
+  truncated: boolean,
+): string {
+  const details = issues.map(issue =>
+    `${formatPath(phase.root, issue.path)}: expected ${issue.expected}; received ${issue.received}`,
+  )
+
+  if (truncated) details.push('Additional configuration issues were not listed.')
+
+  return `Invalid ${phase.name}:\n${details.map(detail => `- ${detail}`).join('\n')}`
+}
+
+function compareIssues(left: ConfigurationIssue, right: ConfigurationIssue): number {
+  const length = Math.min(left.path.length, right.path.length)
+
+  for (let index = 0; index < length; index += 1) {
+    const leftSegment = left.path[index]!
+    const rightSegment = right.path[index]!
+    if (leftSegment === rightSegment) continue
+    if (typeof leftSegment === 'number' && typeof rightSegment === 'string') return -1
+    if (typeof leftSegment === 'string' && typeof rightSegment === 'number') return 1
+    return leftSegment < rightSegment ? -1 : 1
+  }
+
+  if (left.path.length !== right.path.length) {
+    return left.path.length - right.path.length
+  }
+
+  return left.code < right.code ? -1 : left.code > right.code ? 1 : 0
+}
+
+export class ContentMermaidConfigurationError extends Error {
+  readonly code = 'CONTENT_MERMAID_CONFIGURATION_ERROR'
+  override readonly name = 'ContentMermaidConfigurationError'
+
+  constructor(
+    readonly phase: ConfigurationValidationPhase,
+    readonly issues: readonly ConfigurationIssue[],
+    readonly truncated: boolean,
+  ) {
+    super(createMessage(phase, issues, truncated))
+  }
+}
+
+interface IssueCollector {
+  readonly issues: ConfigurationIssue[]
+  truncated: boolean
+}
+
+const ISSUE_LIMIT = 50
+
+function isArrayIndexKey(key: string): boolean {
+  if (!/^(?:0|[1-9]\d*)$/.test(key)) return false
+
+  const index = Number(key)
+  return Number.isInteger(index) && index < 2 ** 32 - 1
+}
+
+function reportIssue(collector: IssueCollector, issue: ConfigurationIssue): void {
+  if (collector.truncated) return
+
+  collector.issues.push(issue)
+  if (collector.issues.length === ISSUE_LIMIT) collector.truncated = true
+}
+
+function collectDescriptorIssues(
+  descriptor: PropertyDescriptor,
+  path: readonly (string | number)[],
+  collector: IssueCollector,
+  ancestors: Set<object>,
+): void {
+  if (!('value' in descriptor)) {
+    reportIssue(collector, {
+      path,
+      code: 'ACCESSOR_PROPERTY',
+      expected: 'an enumerable data property',
+      received: 'accessor',
+    })
+    return
+  }
+
+  if (!descriptor.enumerable) {
+    reportIssue(collector, {
+      path,
+      code: 'NON_ENUMERABLE_PROPERTY',
+      expected: 'an enumerable data property',
+      received: 'non-enumerable-property',
+    })
+    return
+  }
+
+  collectIssues(descriptor.value, path, collector, ancestors)
+}
+
+function collectIssues(
+  value: unknown,
+  path: readonly (string | number)[],
+  collector: IssueCollector,
+  ancestors: Set<object>,
+): void {
+  if (collector.truncated) return
+
+  if (value === undefined) {
+    reportIssue(collector, {
+      path,
+      code: 'UNDEFINED_VALUE',
+      expected: 'strict pure data',
+      received: 'undefined',
+    })
+    return
+  }
+
+  if (typeof value === 'function') {
+    reportIssue(collector, {
+      path,
+      code: 'FUNCTION_VALUE',
+      expected: 'strict pure data',
+      received: 'function',
+    })
+    return
+  }
+
+  if (typeof value === 'symbol') {
+    reportIssue(collector, {
+      path,
+      code: 'SYMBOL_VALUE',
+      expected: 'strict pure data',
+      received: 'symbol',
+    })
+    return
+  }
+
+  if (typeof value === 'bigint') {
+    reportIssue(collector, {
+      path,
+      code: 'BIGINT_VALUE',
+      expected: 'strict pure data',
+      received: 'bigint',
+    })
+    return
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    reportIssue(collector, {
+      path,
+      code: 'NON_FINITE_NUMBER',
+      expected: 'a finite number',
+      received: 'non-finite-number',
+    })
+    return
+  }
+
+  if (typeof value === 'number' && Object.is(value, -0)) {
+    reportIssue(collector, {
+      path,
+      code: 'NEGATIVE_ZERO',
+      expected: 'a finite number other than negative zero',
+      received: 'negative-zero',
+    })
+    return
+  }
+
+  if (value === null || typeof value !== 'object') return
+
+  const prototype = Object.getPrototypeOf(value)
+  if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+    reportIssue(collector, {
+      path,
+      code: 'NON_PLAIN_OBJECT',
+      expected: 'a plain object or array',
+      received: 'non-plain-object',
+    })
+    return
+  }
+
+  if (ancestors.has(value)) {
+    reportIssue(collector, {
+      path,
+      code: 'ANCESTOR_CYCLE',
+      expected: 'an acyclic strict pure-data tree',
+      received: 'ancestor-cycle',
+    })
+    return
+  }
+
+  ancestors.add(value)
+  try {
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    const symbolKeys = Reflect.ownKeys(descriptors).filter(key => typeof key === 'symbol')
+    if (symbolKeys.length > 0) {
+      reportIssue(collector, {
+        path,
+        code: 'SYMBOL_KEY',
+        expected: 'string-keyed strict pure data',
+        received: 'symbol-key',
+      })
+    }
+
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length && !collector.truncated; index += 1) {
+        const descriptor = descriptors[String(index)]
+        const propertyPath = [...path, index]
+        if (!descriptor) {
+          reportIssue(collector, {
+            path: propertyPath,
+            code: 'SPARSE_ARRAY_SLOT',
+            expected: 'a present strict pure-data value',
+            received: 'missing-array-slot',
+          })
+          continue
+        }
+
+        collectDescriptorIssues(descriptor, propertyPath, collector, ancestors)
+      }
+
+      const extraKeys = Object.keys(descriptors)
+        .filter(key => key !== 'length' && !isArrayIndexKey(key))
+        .sort()
+
+      for (const key of extraKeys) {
+        reportIssue(collector, {
+          path: [...path, key],
+          code: 'ARRAY_PROPERTY',
+          expected: 'an array index',
+          received: 'array-property',
+        })
+      }
+      return
+    }
+
+    const keys = Object.keys(descriptors).sort()
+
+    for (const key of keys) {
+      if (collector.truncated) break
+
+      const descriptor = descriptors[key]
+      if (!descriptor) continue
+
+      const propertyPath = [...path, key]
+      collectDescriptorIssues(descriptor, propertyPath, collector, ancestors)
+    }
+  }
+  finally {
+    ancestors.delete(value)
+  }
+}
+
+export function assertStrictData(
+  value: unknown,
+  phase: ConfigurationValidationPhase,
+): asserts value is JsonValue {
+  const collector: IssueCollector = { issues: [], truncated: false }
+  collectIssues(value, [], collector, new Set())
+  collector.issues.sort(compareIssues)
+
+  if (collector.issues.length > 0) {
+    throw new ContentMermaidConfigurationError(
+      phase,
+      collector.issues,
+      collector.truncated,
+    )
+  }
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function assertMergeSafe(value: unknown, ancestors: Set<object>): void {
+  if (value === null || typeof value !== 'object') return
+  if (!Array.isArray(value) && !isPlainObject(value)) {
+    throw new TypeError('Property-Presence Merge accepts only normalized data')
+  }
+  if (ancestors.has(value)) {
+    throw new TypeError('Property-Presence Merge does not accept cyclic data')
+  }
+
+  ancestors.add(value)
+  try {
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    if (Reflect.ownKeys(descriptors).some(key => typeof key === 'symbol')) {
+      throw new TypeError('Property-Presence Merge does not accept symbol keys')
+    }
+
+    for (const key of Object.keys(descriptors)) {
+      if (Array.isArray(value) && key === 'length') continue
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) {
+        throw new TypeError(`Unsafe configuration key: ${key}`)
+      }
+
+      const descriptor = descriptors[key]
+      if (!descriptor || !('value' in descriptor)) {
+        throw new TypeError('Property-Presence Merge does not accept accessors')
+      }
+      assertMergeSafe(descriptor.value, ancestors)
+    }
+  }
+  finally {
+    ancestors.delete(value)
+  }
+}
+
+function defineOwnedProperty(target: object, key: string, value: JsonValue): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+}
+
+function cloneData(value: JsonValue, ancestors: Set<object>): JsonValue {
+  if (value === null || typeof value !== 'object') return value
+  if (!Array.isArray(value) && !isPlainObject(value)) {
+    throw new TypeError('Cannot clone non-plain configuration data')
+  }
+  if (ancestors.has(value)) throw new TypeError('Cannot clone cyclic configuration data')
+
+  ancestors.add(value)
+  try {
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    if (Reflect.ownKeys(descriptors).some(key => typeof key === 'symbol')) {
+      throw new TypeError('Cannot clone symbol-keyed configuration data')
+    }
+
+    if (Array.isArray(value)) {
+      const clone: JsonValue[] = []
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = descriptors[String(index)]
+        if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+          throw new TypeError('Cannot clone non-data configuration properties')
+        }
+        clone.push(cloneData(descriptor.value as JsonValue, ancestors))
+      }
+
+      const extraKeys = Object.keys(descriptors)
+        .filter(key => key !== 'length' && !isArrayIndexKey(key))
+      if (extraKeys.length > 0) {
+        throw new TypeError('Cannot clone non-index array properties')
+      }
+      return clone
+    }
+
+    const clone: JsonObject = {}
+
+    for (const key of Object.keys(descriptors).sort()) {
+      const descriptor = descriptors[key]
+      if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+        throw new TypeError('Cannot clone non-data configuration properties')
+      }
+      defineOwnedProperty(clone, key, cloneData(descriptor.value as JsonValue, ancestors))
+    }
+
+    return clone
+  }
+  finally {
+    ancestors.delete(value)
+  }
+}
+
+export function cloneOwnedData<T extends JsonValue>(value: T): T {
+  return cloneData(value, new Set()) as T
+}
+
+export type DeepReadonlyData<T>
+  = T extends readonly (infer Item)[]
+    ? readonly DeepReadonlyData<Item>[]
+    : T extends object
+      ? { readonly [Key in keyof T]: DeepReadonlyData<T[Key]> }
+      : T
+
+function deepFreezeData(value: JsonValue): void {
+  if (value === null || typeof value !== 'object') return
+
+  const descriptors = Object.getOwnPropertyDescriptors(value)
+  for (const key of Object.keys(descriptors)) {
+    if (Array.isArray(value) && key === 'length') continue
+
+    const descriptor = descriptors[key]
+    if (descriptor && 'value' in descriptor) {
+      deepFreezeData(descriptor.value as JsonValue)
+    }
+  }
+  Object.freeze(value)
+}
+
+export function cloneAndDeepFreezeOwnedData<T extends JsonValue>(
+  value: T,
+): DeepReadonlyData<T> {
+  const clone = cloneOwnedData(value)
+  deepFreezeData(clone)
+  return clone as DeepReadonlyData<T>
+}
+
+function mergeObjects(lower: JsonObject, higher: object): JsonObject {
+  const result = cloneData(lower, new Set()) as JsonObject
+  const higherDescriptors = Object.getOwnPropertyDescriptors(higher)
+
+  for (const key of Object.keys(higherDescriptors).sort()) {
+    const higherDescriptor = higherDescriptors[key]
+    if (!higherDescriptor || !('value' in higherDescriptor)) {
+      throw new TypeError('Cannot merge non-data configuration properties')
+    }
+
+    const lowerDescriptor = Object.getOwnPropertyDescriptor(result, key)
+    const lowerValue = lowerDescriptor && 'value' in lowerDescriptor
+      ? lowerDescriptor.value as JsonValue
+      : undefined
+    const higherValue = higherDescriptor.value as JsonValue
+    const mergedValue = lowerDescriptor && isPlainObject(lowerValue) && isPlainObject(higherValue)
+      ? mergeObjects(lowerValue, higherValue)
+      : cloneData(higherValue, new Set())
+
+    defineOwnedProperty(result, key, mergedValue)
+  }
+
+  return result
+}
+
+export function mergeByPresence(layers: readonly object[]): JsonObject {
+  for (const layer of layers) {
+    if (!isPlainObject(layer)) {
+      throw new TypeError('Property-Presence Merge layers must be plain objects')
+    }
+    assertMergeSafe(layer, new Set())
+  }
+
+  return layers.reduce<JsonObject>(
+    (result, layer) => mergeObjects(result, layer),
+    {},
+  )
+}

--- a/test/configurationCore.test.ts
+++ b/test/configurationCore.test.ts
@@ -1,0 +1,332 @@
+import type { JsonValue } from '../src/types/config'
+import { describe, expect, it } from 'vitest'
+import {
+  ContentMermaidConfigurationError,
+  assertStrictData,
+  cloneAndDeepFreezeOwnedData,
+  cloneOwnedData,
+  mergeByPresence,
+} from '../src/configuration/core'
+
+const runtimeOptionsPhase = {
+  name: 'Runtime Mermaid Options',
+  root: 'runtimeConfig.public.contentMermaid',
+} as const
+
+function captureConfigurationError(value: unknown): ContentMermaidConfigurationError {
+  try {
+    assertStrictData(value, runtimeOptionsPhase)
+  }
+  catch (error) {
+    expect(error).toBeInstanceOf(ContentMermaidConfigurationError)
+    return error as ContentMermaidConfigurationError
+  }
+
+  throw new Error('Expected validation to fail')
+}
+
+describe('configuration core validation', () => {
+  it('reports accessors and invalid safe siblings without executing application behavior', () => {
+    let getterCalls = 0
+    let setterCalls = 0
+    let toJSONCalls = 0
+    const input = {
+      invalidFunction: () => undefined,
+      toJSON: () => {
+        toJSONCalls += 1
+        return {}
+      },
+    }
+
+    Object.defineProperty(input, 'accessor', {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        return 'unsafe'
+      },
+    })
+    Object.defineProperty(input, 'setter', {
+      enumerable: true,
+      set() {
+        setterCalls += 1
+      },
+    })
+
+    const error = captureConfigurationError(input)
+
+    expect(error).toMatchObject({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+      phase: runtimeOptionsPhase,
+      truncated: false,
+      issues: [
+        {
+          path: ['accessor'],
+          code: 'ACCESSOR_PROPERTY',
+          expected: 'an enumerable data property',
+          received: 'accessor',
+        },
+        {
+          path: ['invalidFunction'],
+          code: 'FUNCTION_VALUE',
+          expected: 'strict pure data',
+          received: 'function',
+        },
+        {
+          path: ['setter'],
+          code: 'ACCESSOR_PROPERTY',
+          expected: 'an enumerable data property',
+          received: 'accessor',
+        },
+        {
+          path: ['toJSON'],
+          code: 'FUNCTION_VALUE',
+          expected: 'strict pure data',
+          received: 'function',
+        },
+      ],
+    })
+    expect(error.message).toContain('runtimeConfig.public.contentMermaid.accessor')
+
+    expect(getterCalls).toBe(0)
+    expect(setterCalls).toBe(0)
+    expect(toJSONCalls).toBe(0)
+  })
+
+  it.each([
+    ['undefined', undefined, 'UNDEFINED_VALUE', 'undefined'],
+    ['symbol', Symbol('invalid'), 'SYMBOL_VALUE', 'symbol'],
+    ['bigint', 1n, 'BIGINT_VALUE', 'bigint'],
+    ['NaN', Number.NaN, 'NON_FINITE_NUMBER', 'non-finite-number'],
+    ['positive infinity', Number.POSITIVE_INFINITY, 'NON_FINITE_NUMBER', 'non-finite-number'],
+    ['negative infinity', Number.NEGATIVE_INFINITY, 'NON_FINITE_NUMBER', 'non-finite-number'],
+    ['negative zero', -0, 'NEGATIVE_ZERO', 'negative-zero'],
+    ['non-plain instance', new Date(0), 'NON_PLAIN_OBJECT', 'non-plain-object'],
+  ])('rejects %s as strict pure data', (_label, value, code, received) => {
+    expect(captureConfigurationError(value)).toMatchObject({
+      issues: [{ path: [], code, received }],
+      truncated: false,
+    })
+  })
+
+  it('reports ancestor cycles while validating shared references at every reachable path', () => {
+    const shared = { invalid: undefined }
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    const input = {
+      first: shared,
+      second: shared,
+      cyclic,
+    }
+
+    expect(captureConfigurationError(input)).toMatchObject({
+      issues: [
+        { path: ['cyclic', 'self'], code: 'ANCESTOR_CYCLE' },
+        { path: ['first', 'invalid'], code: 'UNDEFINED_VALUE' },
+        { path: ['second', 'invalid'], code: 'UNDEFINED_VALUE' },
+      ],
+    })
+  })
+
+  it('rejects non-transport object and array structure with deterministic paths', () => {
+    const sparse: unknown[] & { extra?: boolean } = []
+    sparse.length = 3
+    sparse[1] = 'present'
+    sparse.extra = true
+    const input = { sparse }
+
+    Object.defineProperty(input, 'hidden', {
+      enumerable: false,
+      value: 'not transported',
+    })
+    Object.defineProperty(input, Symbol('symbol-key'), {
+      enumerable: true,
+      value: 'not addressable',
+    })
+
+    expect(captureConfigurationError(input)).toMatchObject({
+      issues: [
+        { path: [], code: 'SYMBOL_KEY' },
+        { path: ['hidden'], code: 'NON_ENUMERABLE_PROPERTY' },
+        { path: ['sparse', 0], code: 'SPARSE_ARRAY_SLOT' },
+        { path: ['sparse', 2], code: 'SPARSE_ARRAY_SLOT' },
+        { path: ['sparse', 'extra'], code: 'ARRAY_PROPERTY' },
+      ],
+    })
+  })
+
+  it('stops on the fiftieth safely observable issue and reports truncation', () => {
+    const input = Array.from({ length: 50 }, () => undefined)
+
+    const error = captureConfigurationError(input)
+
+    expect(error).toMatchObject({ truncated: true })
+    expect(error.issues).toHaveLength(50)
+    expect(error.issues[0]?.path).toEqual([0])
+    expect(error.issues[49]?.path).toEqual([49])
+    expect(error.message).toContain('Additional configuration issues were not listed.')
+  })
+
+  it('accepts the agreed primitives, dense arrays, plain objects, and shared references', () => {
+    const shared = { value: 'shared' }
+    const nullPrototype = Object.create(null) as Record<string, unknown>
+    nullPrototype.nested = [null, true, false, 0, 1.5, '', 'value']
+
+    expect(() => assertStrictData({ shared, again: shared, nullPrototype }, runtimeOptionsPhase))
+      .not.toThrow()
+  })
+
+  it('rejects numeric-looking array properties that are outside the index range', () => {
+    const input: unknown[] = []
+    Object.defineProperty(input, '4294967295', {
+      enumerable: true,
+      value: 'not an array index',
+    })
+
+    expect(captureConfigurationError(input)).toMatchObject({
+      issues: [{ path: ['4294967295'], code: 'ARRAY_PROPERTY' }],
+    })
+  })
+})
+
+describe('property-presence merge', () => {
+  it('merges layers in order while preserving every explicit replacement value', () => {
+    const lowest = {
+      nested: { inherited: 'lowest' },
+      array: ['lowest'],
+      nullable: 'fallback',
+      enabled: true,
+      count: 1,
+      label: 'fallback',
+    }
+    const middle = {
+      nested: null,
+      array: ['middle'],
+    }
+    const highest = {
+      nested: { highest: true },
+      array: [],
+      nullable: null,
+      enabled: false,
+      count: 0,
+      label: '',
+    }
+
+    const result = mergeByPresence([lowest, middle, highest])
+
+    expect(result).toEqual({
+      nested: { highest: true },
+      array: [],
+      nullable: null,
+      enabled: false,
+      count: 0,
+      label: '',
+    })
+    expect(result).not.toBe(highest)
+    expect(result.nested).not.toBe(highest.nested)
+    expect(result.array).not.toBe(highest.array)
+    expect(lowest).toEqual({
+      nested: { inherited: 'lowest' },
+      array: ['lowest'],
+      nullable: 'fallback',
+      enabled: true,
+      count: 1,
+      label: 'fallback',
+    })
+  })
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects the prototype-pollution key %s at any depth',
+    (unsafeKey) => {
+      const nested = Object.create(null) as Record<string, unknown>
+      Object.defineProperty(nested, unsafeKey, {
+        enumerable: true,
+        value: { polluted: true },
+      })
+
+      expect(() => mergeByPresence([{ safe: { nested } }])).toThrow(
+        `Unsafe configuration key: ${unsafeKey}`,
+      )
+      expect(Object.prototype).not.toHaveProperty('polluted')
+    },
+  )
+
+  it('does not invoke accessors while rejecting an unnormalized layer', () => {
+    let getterCalls = 0
+    const layer = {}
+    Object.defineProperty(layer, 'unsafe', {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        return 'unsafe'
+      },
+    })
+
+    expect(() => mergeByPresence([layer])).toThrow(
+      'Property-Presence Merge does not accept accessors',
+    )
+    expect(getterCalls).toBe(0)
+  })
+})
+
+describe('owned configuration data', () => {
+  it('clones every reachable path without retaining mutable transport references', () => {
+    const shared = { nested: { value: 'transport' } }
+    const input = {
+      first: shared,
+      second: shared,
+      list: [shared],
+    }
+
+    const clone = cloneOwnedData(input)
+
+    expect(clone).toEqual(input)
+    expect(clone).not.toBe(input)
+    expect(clone.first).not.toBe(shared)
+    expect(clone.second).not.toBe(shared)
+    expect(clone.first).not.toBe(clone.second)
+    expect(clone.list).not.toBe(input.list)
+    expect(clone.list[0]).not.toBe(shared)
+
+    clone.first.nested.value = 'owned'
+    expect(shared.nested.value).toBe('transport')
+    expect(clone.second.nested.value).toBe('transport')
+  })
+
+  it('deep-freezes an owned clone without freezing transport input', () => {
+    const input = {
+      nested: { value: 'transport' },
+      list: [{ enabled: true }],
+    }
+
+    const frozen = cloneAndDeepFreezeOwnedData(input)
+
+    expect(frozen).toEqual(input)
+    expect(frozen).not.toBe(input)
+    expect(frozen.nested).not.toBe(input.nested)
+    expect(frozen.list).not.toBe(input.list)
+    expect(Object.isFrozen(frozen)).toBe(true)
+    expect(Object.isFrozen(frozen.nested)).toBe(true)
+    expect(Object.isFrozen(frozen.list)).toBe(true)
+    expect(Object.isFrozen(frozen.list[0])).toBe(true)
+    expect(Object.isFrozen(input)).toBe(false)
+    expect(Object.isFrozen(input.nested)).toBe(false)
+  })
+
+  it('does not invoke array accessors when rejecting invalid clone input', () => {
+    let getterCalls = 0
+    const input: unknown[] = []
+    Object.defineProperty(input, 0, {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        return 'unsafe'
+      },
+    })
+
+    expect(() => cloneOwnedData(input as JsonValue)).toThrow(
+      'Cannot clone non-data configuration properties',
+    )
+    expect(getterCalls).toBe(0)
+  })
+})

--- a/test/packageContract.test.ts
+++ b/test/packageContract.test.ts
@@ -6,5 +6,7 @@ describe('package root runtime contract', () => {
 
     expect(packageModule.default).toBeDefined()
     expect('transformMermaidCodeBlocks' in packageModule).toBe(false)
+    expect('ContentMermaidConfigurationError' in packageModule).toBe(false)
+    expect('ConfigurationIssue' in packageModule).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- add one package-owned configuration core for descriptor-safe strict pure-data validation
- add deterministic phase-scoped diagnostics with structured paths, ancestor-cycle handling, and a 50-issue cap
- add Property-Presence Merge plus owned clone and deep-freeze primitives
- verify diagnostic classes and internal issue structures stay out of the package root

## Impact

This establishes the shared ownership and failure semantics required by later v3 configuration resolvers without wiring those resolvers ahead of their tickets.

## Validation

- `pnpm exec vitest run --exclude '.worktrees/**' --maxWorkers=1` — 18 files, 121 tests passed
- `pnpm test:types`
- `pnpm exec eslint . --ignore-pattern '.worktrees/**'`
- `pnpm test:package-contract`
- `git diff --check`

Closes #23
