### PR TITLE
feat: preserve committed diagrams transactionally

### DIFF
--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -273,7 +273,7 @@ function getBuiltInRenderRequest() {
       config: effectiveMermaidInit.value,
       target: mermaidContainer.value,
     }),
-    prepare: () => {
+    beforeCommit: () => {
       if (import.meta.client) {
         expandOverlay.value?.endForDiagramReplacement()
         void fullscreenPresentation.value?.endForDiagramReplacement()
@@ -450,6 +450,9 @@ async function renderMermaid() {
 
   const outcome = await getBuiltInRenderRequest()()
 
+  if (outcome.status === 'stale')
+    return
+
   if (outcome.status === 'success') {
     hasRenderedOnce.value = true
   }
@@ -549,6 +552,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  requestBuiltInRender?.invalidate()
   if (observer) observer.disconnect()
   if (copyResetTimer) clearTimeout(copyResetTimer)
 })

--- a/src/runtime/mermaid-rendering.ts
+++ b/src/runtime/mermaid-rendering.ts
@@ -1,9 +1,9 @@
 import type { Mermaid, MermaidConfig } from 'mermaid'
-import { nextTick } from 'vue'
 import { MERMAID_LOG_PREFIX } from './constants'
 
 let renderQueue = Promise.resolve()
 let queueSize = 0
+let renderId = 0
 
 export interface MermaidRenderData {
   source: string | null | undefined
@@ -13,27 +13,36 @@ export interface MermaidRenderData {
 
 export type MermaidRenderOutcome
   = | { status: 'skipped' }
+    | { status: 'stale' }
     | { status: 'success' }
     | { status: 'failure', error: unknown }
 
 export interface MermaidRendererDependencies {
   loadMermaid: () => Promise<Mermaid>
   readRenderData: () => MermaidRenderData
-  prepare: () => void
+  beforeCommit: () => void
   debug: boolean
+}
+
+export interface MermaidRenderRequest {
+  (): Promise<MermaidRenderOutcome>
+  invalidate: () => void
 }
 
 /** @internal */
 export function createMermaidRenderer(
   dependencies: MermaidRendererDependencies,
-): () => Promise<MermaidRenderOutcome> {
+): MermaidRenderRequest {
   if (dependencies.debug) {
     console.log(MERMAID_LOG_PREFIX, {
       event: 'renderer:create',
     })
   }
 
-  return () => {
+  let latestGeneration = 0
+
+  const request: MermaidRenderRequest = () => {
+    const generation = ++latestGeneration
     queueSize++
     if (dependencies.debug) {
       console.log(MERMAID_LOG_PREFIX, {
@@ -44,6 +53,7 @@ export function createMermaidRenderer(
 
     const render = async (): Promise<MermaidRenderOutcome> => {
       let target: HTMLDivElement | null | undefined
+      let stagingRoot: HTMLDivElement | undefined
       let attemptStart: number | undefined
 
       if (dependencies.debug) {
@@ -54,6 +64,9 @@ export function createMermaidRenderer(
       }
 
       try {
+        if (generation !== latestGeneration)
+          return { status: 'stale' }
+
         const renderData = dependencies.readRenderData()
         const { source, config } = renderData
         target = renderData.target
@@ -64,34 +77,40 @@ export function createMermaidRenderer(
         if (dependencies.debug)
           attemptStart = performance.now()
 
-        dependencies.prepare()
-
         const mermaid = await dependencies.loadMermaid()
         mermaid.initialize(config)
-        target.removeAttribute('data-processed')
-        target.textContent = source
-        await nextTick()
 
-        await mermaid.run({
-          nodes: [target],
-          suppressErrors: !dependencies.debug,
-        })
+        const staging = createStagingTarget(target)
+        stagingRoot = staging.root
+        const result = await mermaid.render(
+          `nuxt-content-mermaid-${++renderId}`,
+          source,
+          staging.target,
+        )
 
-        const svg = target.querySelector('svg')
+        if (generation !== latestGeneration)
+          return { status: 'stale' }
+
+        staging.target.innerHTML = result.svg
+
+        const svg = staging.target.querySelector('svg')
         if (svg)
           ensureViewBox(svg)
+
+        result.bindFunctions?.(staging.target)
+
+        if (generation !== latestGeneration)
+          return { status: 'stale' }
+
+        // The commit phase must not yield after this final eligibility check.
+        dependencies.beforeCommit()
+        target.replaceChildren(...staging.target.childNodes)
 
         return { status: 'success' }
       }
       catch (error) {
-        if (target) {
-          try {
-            target.innerHTML = ''
-          }
-          catch {
-            // Preserve the original failure when cleanup itself cannot complete.
-          }
-        }
+        if (generation !== latestGeneration)
+          return { status: 'stale' }
 
         if (dependencies.debug) {
           console.error(
@@ -104,6 +123,9 @@ export function createMermaidRenderer(
         return { status: 'failure', error }
       }
       finally {
+        if (stagingRoot)
+          removeStagingRoot(stagingRoot)
+
         if (dependencies.debug && attemptStart !== undefined) {
           console.log(MERMAID_LOG_PREFIX, {
             event: 'attempt:duration',
@@ -128,6 +150,47 @@ export function createMermaidRenderer(
     )
     return outcome
   }
+
+  request.invalidate = () => {
+    latestGeneration++
+  }
+
+  return request
+}
+
+function removeStagingRoot(root: HTMLDivElement) {
+  const parent = root.parentNode
+  try {
+    root.remove()
+  }
+  catch {
+    try {
+      parent?.removeChild(root)
+    }
+    catch {
+      // Cleanup must not replace the Render Outcome with a secondary DOM error.
+    }
+  }
+}
+
+function createStagingTarget(target: HTMLDivElement) {
+  const document = target.ownerDocument
+  const root = document.createElement('div')
+  const stagingTarget = document.createElement('div')
+
+  root.setAttribute('aria-hidden', 'true')
+  root.inert = true
+  root.tabIndex = -1
+  root.style.position = 'fixed'
+  root.style.left = '-100000px'
+  root.style.top = '0'
+  root.style.opacity = '0'
+  root.style.pointerEvents = 'none'
+  root.style.zIndex = '-1'
+  root.appendChild(stagingTarget)
+  document.body.appendChild(root)
+
+  return { root, target: stagingTarget }
 }
 
 function ensureViewBox(svg: SVGSVGElement) {

--- a/test/builtInRenderer.e2e.test.ts
+++ b/test/builtInRenderer.e2e.test.ts
@@ -13,7 +13,7 @@ type BrowserPage = Awaited<ReturnType<typeof createPage>>
 async function waitForPending(page: BrowserPage, expected: number) {
   await page.waitForFunction((count: number) => {
     return (window as MermaidTestWindow).__mermaidControl__?.pending === count
-  }, expected)
+  }, expected, { timeout: 5000 })
 }
 
 async function releaseNext(page: BrowserPage) {
@@ -25,7 +25,7 @@ async function releaseNext(page: BrowserPage) {
 async function waitForRuns(page: BrowserPage, expected: number) {
   await page.waitForFunction((count: number) => {
     return (window as MermaidTestWindow).__mermaidControl__?.runs.length === count
-  }, expected)
+  }, expected, { timeout: 5000 })
 }
 
 async function waitForDiagnosticCount(page: BrowserPage, event: string, expected: number) {
@@ -35,7 +35,29 @@ async function waitForDiagnosticCount(page: BrowserPage, event: string, expected
       return events.filter(value => value === eventName).length >= count
     },
     { eventName: event, count: expected },
+    { timeout: 5000 },
   )
+}
+
+async function installFullscreenStub(page: BrowserPage) {
+  await page.addInitScript(() => {
+    const defineWritable = (target: object, key: string, value: unknown) => {
+      Object.defineProperty(target, key, { value, writable: true, configurable: true })
+    }
+
+    defineWritable(document, 'fullScreen', false)
+    defineWritable(document, 'fullscreenElement', null)
+    defineWritable(document, 'exitFullscreen', async () => {
+      ;(document as { fullScreen?: boolean }).fullScreen = false
+      ;(document as { fullscreenElement?: Element | null }).fullscreenElement = null
+      document.dispatchEvent(new Event('fullscreenchange'))
+    })
+    defineWritable(HTMLElement.prototype, 'requestFullscreen', async function (this: HTMLElement) {
+      ;(document as { fullScreen?: boolean }).fullScreen = true
+      ;(document as { fullscreenElement?: Element | null }).fullscreenElement = this
+      document.dispatchEvent(new Event('fullscreenchange'))
+    })
+  })
 }
 
 async function renderInitialDiagram(page: BrowserPage) {
@@ -68,8 +90,9 @@ describe('built-in renderer integration', async () => {
     ]))
   })
 
-  it('keeps an existing error while recovery waits and clears it at attempt start', { timeout: 20000 }, async () => {
+  it('preserves the Committed Diagram through failure and pending recovery', { timeout: 20000 }, async () => {
     const page = await createPage()
+    await installDiagnosticCapture(page)
     await renderInitialDiagram(page)
 
     await page.locator('#primary-fail').click()
@@ -80,17 +103,21 @@ describe('built-in renderer integration', async () => {
     await error.waitFor({ state: 'visible', timeout: 5000 })
     expect(await error.getAttribute('data-same-error')).toBe('true')
     expect(await page.getByTestId('built-in-error-message').textContent()).toBe('Broken diagram')
+    expect(await page.locator('#primary .mermaid > svg').getAttribute('data-run-id')).toBe('1')
 
-    await page.locator('#blocker-mount').click()
-    await waitForRuns(page, 3)
     await page.locator('#primary-recover').click()
-    expect(await error.isVisible()).toBe(true)
+    await waitForRuns(page, 3)
+    await page.locator('#primary-queue').click()
+    await waitForDiagnosticCount(page, 'queue:enqueue', 4)
 
     await releaseNext(page)
     await waitForRuns(page, 4)
-    await error.waitFor({ state: 'detached', timeout: 5000 })
     await waitForPending(page, 1)
+    expect(await error.isVisible()).toBe(true)
+    expect(await page.locator('#primary .mermaid > svg').getAttribute('data-run-id')).toBe('1')
+
     await releaseNext(page)
+    await error.waitFor({ state: 'detached', timeout: 5000 })
     await page.locator('#primary svg[data-run-id="4"]').waitFor({ state: 'visible', timeout: 5000 })
   })
 
@@ -120,59 +147,120 @@ describe('built-in renderer integration', async () => {
     expect(await page.locator('#skipped [data-testid="built-in-error"]').count()).toBe(0)
   })
 
-  it('preserves first-completion-wins loading with multiple pending requests', { timeout: 20000 }, async () => {
+  it('commits strict SVG and sandbox iframe output from cleaned staging hosts', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+
+    await page.locator('#strict-mount').click()
+    await waitForRuns(page, 2)
+    await releaseNext(page)
+    await page.locator('#strict .mermaid > svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+
+    await page.locator('#sandbox-mount').click()
+    await waitForRuns(page, 3)
+    await releaseNext(page)
+    await page.locator('#sandbox .mermaid > iframe[data-run-id="3"]').waitFor({ state: 'visible', timeout: 5000 })
+
+    const staging = await page.evaluate(() => {
+      const control = (window as MermaidTestWindow).__mermaidControl__
+      return {
+        runs: control?.runs,
+        allRootsRemoved: control?.stagingRoots.every(root => !root.isConnected),
+      }
+    })
+
+    expect(staging.runs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 2,
+        securityLevel: 'strict',
+        stagingConnected: true,
+        stagingHidden: true,
+        stagingInert: true,
+        stagingOutsideLiveSubtree: true,
+      }),
+      expect.objectContaining({
+        id: 3,
+        securityLevel: 'sandbox',
+        stagingConnected: true,
+        stagingHidden: true,
+        stagingInert: true,
+        stagingOutsideLiveSubtree: true,
+      }),
+    ]))
+    expect(staging.allRootsRemoved).toBe(true)
+  })
+
+  it('keeps presentation state until only the latest generation commits', { timeout: 20000 }, async () => {
     const page = await createPage()
     await installDiagnosticCapture(page)
     await renderInitialDiagram(page)
 
-    await page.locator('#blocker-mount').click()
-    await waitForRuns(page, 2)
-    await releaseNext(page)
-    await page.locator('#blocker svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
-
-    await page.locator('#primary-queue').click()
-    await waitForRuns(page, 3)
-    await page.locator('#blocker-update').click()
-    await page.locator('#primary-queue').click()
-    await waitForDiagnosticCount(page, 'queue:enqueue', 5)
-
-    await releaseNext(page)
-    await waitForRuns(page, 4)
-    await waitForPending(page, 1)
-    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())))
-
     await page.locator('#primary [aria-label="Expand diagram"]').click()
     await page.locator('.ncm-expand-modal').waitFor({ state: 'visible', timeout: 5000 })
 
-    const activeInteraction = await page.evaluate(() => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ', bubbles: true, cancelable: true }))
-      const modal = document.querySelector('.ncm-expand-modal')
-      modal?.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true, cancelable: true }))
-      const target = document.querySelector('.ncm-expand-target')
-      target?.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }))
-      return document.body.style.userSelect
-    })
-    expect(activeInteraction).toBe('none')
-    await page.locator('.ncm-zoom-hint').waitFor({ state: 'visible', timeout: 2000 })
+    await page.locator('#primary-queue').evaluate((button: HTMLButtonElement) => button.click())
+    await waitForRuns(page, 2)
+    await page.locator('#primary-queue').evaluate((button: HTMLButtonElement) => button.click())
+    await waitForDiagnosticCount(page, 'queue:enqueue', 3)
 
     await releaseNext(page)
-    await waitForRuns(page, 5)
-    await page.locator('.ncm-expand-modal').waitFor({ state: 'detached', timeout: 5000 })
-    expect(await page.locator('.ncm-zoom-hint, .ncm-expand-target svg').count()).toBe(0)
-    expect(await page.evaluate(() => {
-      const wheel = new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true })
-      const key = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
-      window.dispatchEvent(wheel)
-      document.dispatchEvent(key)
-      return {
-        wheel: wheel.defaultPrevented,
-        key: key.defaultPrevented,
-        overflow: document.body.style.overflow,
-        width: document.body.style.width,
-        userSelect: document.body.style.userSelect,
-      }
-    })).toEqual({ wheel: false, key: false, overflow: '', width: '', userSelect: '' })
+    await waitForRuns(page, 3)
+    await waitForPending(page, 1)
+    await page.locator('.ncm-expand-modal').waitFor({ state: 'visible', timeout: 5000 })
+    expect(await page.locator('#primary .mermaid > svg').getAttribute('data-run-id')).toBe('1')
+
     await releaseNext(page)
-    await page.locator('#primary svg[data-run-id="5"]').waitFor({ state: 'visible', timeout: 5000 })
+    await page.locator('.ncm-expand-modal').waitFor({ state: 'detached', timeout: 5000 })
+    await page.locator('#primary svg[data-run-id="3"]').waitFor({ state: 'visible', timeout: 5000 })
+  })
+
+  it('keeps the latest loading gate while a stale attempt finishes', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await installDiagnosticCapture(page)
+    await renderInitialDiagram(page)
+
+    await page.locator('#primary-queue').click()
+    await waitForRuns(page, 2)
+    await page.locator('#primary-queue').click()
+    await waitForDiagnosticCount(page, 'queue:enqueue', 3)
+
+    await releaseNext(page)
+    await waitForRuns(page, 3)
+    await waitForPending(page, 1)
+    await page.locator('#primary [aria-label="Expand diagram"]').click()
+    expect(await page.locator('.ncm-expand-modal').count()).toBe(0)
+    expect(await page.locator('#primary .mermaid > svg').getAttribute('data-run-id')).toBe('1')
+
+    await releaseNext(page)
+    await page.locator('#primary svg[data-run-id="3"]').waitFor({ state: 'visible', timeout: 5000 })
+    await page.locator('#primary [aria-label="Expand diagram"]').click()
+    await page.locator('.ncm-expand-modal').waitFor({ state: 'visible', timeout: 5000 })
+  })
+
+  it('keeps fullscreen presentation until the latest generation commits', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await installDiagnosticCapture(page)
+    await installFullscreenStub(page)
+    await renderInitialDiagram(page)
+
+    await page.locator('#primary [aria-label="Enter fullscreen"]').click()
+    await page.locator('#primary .ncm-zoom-toolbar--fullscreen').waitFor({ state: 'visible', timeout: 5000 })
+
+    await page.locator('#primary-queue').evaluate((button: HTMLButtonElement) => button.click())
+    await waitForRuns(page, 2)
+    await page.locator('#primary-queue').evaluate((button: HTMLButtonElement) => button.click())
+    await waitForDiagnosticCount(page, 'queue:enqueue', 3)
+
+    await releaseNext(page)
+    await waitForRuns(page, 3)
+    await waitForPending(page, 1)
+    await page.locator('#primary .ncm-zoom-toolbar--fullscreen').waitFor({ state: 'visible', timeout: 5000 })
+    expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true)
+    expect(await page.locator('#primary .mermaid > svg').getAttribute('data-run-id')).toBe('1')
+
+    await releaseNext(page)
+    await page.locator('#primary .ncm-zoom-toolbar--fullscreen').waitFor({ state: 'detached', timeout: 5000 })
+    expect(await page.evaluate(() => document.fullscreenElement)).toBeNull()
+    await page.locator('#primary svg[data-run-id="3"]').waitFor({ state: 'visible', timeout: 5000 })
   })
 })

--- a/test/fixtures/built-in-renderer/app.vue
+++ b/test/fixtures/built-in-renderer/app.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import type { MermaidConfig } from 'mermaid'
 
 const primaryVersion = ref(0)
 const primaryCode = ref('graph TD;INITIAL-->DONE')
@@ -7,6 +8,10 @@ const blockerVersion = ref(0)
 const showBlocker = ref(false)
 const skippedCode = ref('graph TD;SKIPPED-->DONE')
 const showSkipped = ref(false)
+const showStrict = ref(false)
+const showSandbox = ref(false)
+const strictConfig: MermaidConfig = { securityLevel: 'strict' }
+const sandboxConfig: MermaidConfig = { securityLevel: 'sandbox' }
 
 const encodedPrimary = computed(() => encodeURIComponent(primaryCode.value))
 const encodedBlocker = computed(() => encodeURIComponent(`graph TD;BLOCKER_${blockerVersion.value}-->DONE`))
@@ -44,6 +49,14 @@ function mountSkipped() {
 
 function clearSkipped() {
   skippedCode.value = ''
+}
+
+function mountStrict() {
+  showStrict.value = true
+}
+
+function mountSandbox() {
+  showSandbox.value = true
 }
 </script>
 
@@ -106,6 +119,20 @@ function clearSkipped() {
       >
         Clear skipped
       </button>
+      <button
+        id="strict-mount"
+        type="button"
+        @click="mountStrict"
+      >
+        Mount strict
+      </button>
+      <button
+        id="sandbox-mount"
+        type="button"
+        @click="mountSandbox"
+      >
+        Mount sandbox
+      </button>
     </div>
 
     <section id="primary">
@@ -124,6 +151,26 @@ function clearSkipped() {
       id="skipped"
     >
       <Mermaid :code="encodedSkipped" />
+    </section>
+
+    <section
+      v-if="showStrict"
+      id="strict"
+    >
+      <Mermaid
+        :code="encodeURIComponent('graph TD;STRICT-->DONE')"
+        :config="strictConfig"
+      />
+    </section>
+
+    <section
+      v-if="showSandbox"
+      id="sandbox"
+    >
+      <Mermaid
+        :code="encodeURIComponent('graph TD;SANDBOX-->DONE')"
+        :config="sandboxConfig"
+      />
     </section>
   </main>
 </template>

--- a/test/fixtures/built-in-renderer/mermaid-stub.ts
+++ b/test/fixtures/built-in-renderer/mermaid-stub.ts
@@ -1,9 +1,12 @@
+import type { MermaidConfig } from 'mermaid'
 import type { MermaidControl, MermaidTestWindow } from './types'
 
 const pendingResolvers: Array<() => void> = []
+let currentSecurityLevel: MermaidConfig['securityLevel']
 const control: MermaidControl = {
   pending: 0,
   runs: [],
+  stagingRoots: [],
   releaseNext() {
     pendingResolvers.shift()?.()
   },
@@ -13,14 +16,24 @@ if (typeof window !== 'undefined')
   (window as MermaidTestWindow).__mermaidControl__ = control
 
 const mermaidStub = {
-  initialize: () => {},
-  run: async ({ nodes }: { nodes?: HTMLElement[] } = {}) => {
-    const target = nodes?.[0]
-    if (!target) return
-
-    const source = target.textContent || ''
+  initialize: (config: MermaidConfig) => {
+    currentSecurityLevel = config.securityLevel
+  },
+  render: async (_renderId: string, source: string, stagingTarget?: Element) => {
     const id = control.runs.length + 1
-    control.runs.push({ source, id })
+    const stagingRoot = stagingTarget?.parentElement
+    if (stagingRoot)
+      control.stagingRoots.push(stagingRoot)
+
+    control.runs.push({
+      source,
+      id,
+      securityLevel: currentSecurityLevel,
+      stagingConnected: stagingTarget?.isConnected === true,
+      stagingHidden: stagingRoot?.getAttribute('aria-hidden') === 'true',
+      stagingInert: stagingRoot?.inert === true && stagingRoot.style.pointerEvents === 'none',
+      stagingOutsideLiveSubtree: stagingTarget?.closest('.mermaid') === null,
+    })
     control.pending++
     await new Promise<void>(resolve => pendingResolvers.push(resolve))
     control.pending--
@@ -31,12 +44,12 @@ const mermaidStub = {
       throw error
     }
 
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-    svg.setAttribute('data-run-id', String(id))
-    svg.setAttribute('data-source', source)
-    svg.setAttribute('width', '600')
-    svg.setAttribute('height', '400')
-    target.replaceChildren(svg)
+    return {
+      diagramType: 'flowchart',
+      svg: currentSecurityLevel === 'sandbox'
+        ? `<iframe data-run-id="${id}" data-source="${source}"></iframe>`
+        : `<svg data-run-id="${id}" data-source="${source}" width="600" height="400"></svg>`,
+    }
   },
 }
 

--- a/test/fixtures/built-in-renderer/types.ts
+++ b/test/fixtures/built-in-renderer/types.ts
@@ -1,6 +1,19 @@
+import type { MermaidConfig } from 'mermaid'
+
+export interface MermaidRun {
+  source: string
+  id: number
+  securityLevel: MermaidConfig['securityLevel']
+  stagingConnected: boolean
+  stagingHidden: boolean
+  stagingInert: boolean
+  stagingOutsideLiveSubtree: boolean
+}
+
 export interface MermaidControl {
   pending: number
-  runs: Array<{ source: string, id: number }>
+  runs: MermaidRun[]
+  stagingRoots: HTMLElement[]
   lastError?: Error
   releaseNext: () => void
 }

--- a/test/fixtures/color-mode/mermaid-stub.ts
+++ b/test/fixtures/color-mode/mermaid-stub.ts
@@ -22,7 +22,10 @@ const mermaidStub = {
   initialize: (config: MermaidInitConfig) => {
     calls.push(config)
   },
-  run: async () => {},
+  render: async () => ({
+    diagramType: 'flowchart',
+    svg: '<svg width="600" height="400"></svg>',
+  }),
 }
 
 export default mermaidStub

--- a/test/fixtures/custom-components/mermaid-stub.ts
+++ b/test/fixtures/custom-components/mermaid-stub.ts
@@ -19,12 +19,8 @@ const mermaidStub = {
   initialize: (config: Record<string, unknown>) => {
     calls.push(config)
   },
-  run: async ({ nodes }: { nodes?: HTMLElement[] } = {}) => {
+  render: async (_renderId: string, source: string) => {
     await new Promise(resolve => setTimeout(resolve, 200))
-    const container = nodes?.[0]
-    if (!container) return
-
-    const source = container.textContent || ''
     const shouldThrow = source.includes('__FORCE_ERROR__')
       || ((globalThis as GlobalMermaidStub).__forceMermaidError === true)
     runs.push({ source, threw: shouldThrow })
@@ -33,7 +29,10 @@ const mermaidStub = {
       throw new Error('Broken diagram')
     }
 
-    container.innerHTML = '<svg id="mock-svg"></svg>'
+    return {
+      diagramType: 'flowchart',
+      svg: '<svg id="mock-svg"></svg>',
+    }
   },
 }
 

--- a/test/fixtures/custom-renderer/mermaid-stub.ts
+++ b/test/fixtures/custom-renderer/mermaid-stub.ts
@@ -7,9 +7,14 @@ if (typeof window !== 'undefined')
 
 const mermaidStub = {
   initialize: () => {},
-  run: async () => {
+  render: async () => {
     if (typeof window !== 'undefined')
       (window as TestWindow).__builtInMermaidRunCount__ = ((window as TestWindow).__builtInMermaidRunCount__ || 0) + 1
+
+    return {
+      diagramType: 'flowchart',
+      svg: '<svg></svg>',
+    }
   },
 }
 

--- a/test/fixtures/expand-toolbar/mermaid-stub.ts
+++ b/test/fixtures/expand-toolbar/mermaid-stub.ts
@@ -12,15 +12,14 @@ if (typeof window !== 'undefined') {
 
 const mermaidStub = {
   initialize: () => {},
-  run: async ({ nodes }: { nodes?: HTMLElement[] } = {}) => {
-    const container = nodes?.[0]
-    if (!container) return
-
-    const source = container.textContent || ''
+  render: async (_renderId: string, source: string) => {
     runs.push({ source })
 
     const id = source.includes('SECONDARY') ? 'mock-svg-secondary' : 'mock-svg'
-    container.innerHTML = `<svg id="${id}" width="600" height="400"></svg>`
+    return {
+      diagramType: 'flowchart',
+      svg: `<svg id="${id}" width="600" height="400"></svg>`,
+    }
   },
 }
 

--- a/test/mermaidRendering.test.ts
+++ b/test/mermaidRendering.test.ts
@@ -1,58 +1,144 @@
 import type { Mermaid, MermaidConfig } from 'mermaid'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { scheduler } = vi.hoisted(() => ({
-  scheduler: { events: [] as string[] },
-}))
-
-vi.mock('vue', () => ({
-  nextTick: vi.fn(async () => {
-    scheduler.events.push('scheduler')
-  }),
-}))
-
-function createTarget(events: string[], svg: SVGSVGElement | null = null) {
-  let content = ''
-
-  const target = {
-    removeAttribute: vi.fn((name: string) => {
-      events.push(`remove:${name}`)
-    }),
-    get textContent() {
-      return content
-    },
-    set textContent(value: string | null) {
-      content = value ?? ''
-      events.push(`write:${content}`)
-    },
-    get innerHTML() {
-      return content
-    },
-    set innerHTML(value: string) {
-      content = value
-      events.push(`html:${value}`)
-    },
-    querySelector: vi.fn((selector: string) => {
-      events.push(`query:${selector}`)
-      return svg
-    }),
-  } as unknown as HTMLDivElement
-
-  return {
-    target,
-    readContent: () => content,
-  }
-}
-
-function asMermaid(value: Pick<Mermaid, 'initialize' | 'run'>): Mermaid {
+function asMermaid(value: object): Mermaid {
   return value as Mermaid
 }
 
-describe('createMermaidRenderer', () => {
-  beforeEach(() => {
-    scheduler.events = []
-  })
+class TestElement {
+  readonly attributes = new Map<string, string>()
+  readonly childNodes: TestElement[] = []
+  readonly style: Record<string, string> = {}
+  parentNode: TestElement | null = null
+  inert = false
+  tabIndex = 0
 
+  constructor(
+    readonly tagName: string,
+    readonly ownerDocument: TestDocument,
+    private readonly events: string[],
+  ) {}
+
+  get isConnected(): boolean {
+    return this === this.ownerDocument.body || this.parentNode?.isConnected === true
+  }
+
+  get textContent() {
+    return this.childNodes.map(node => node.textContent).join('')
+  }
+
+  set textContent(value: string) {
+    this.replaceChildren()
+    if (value) {
+      const text = this.ownerDocument.createElement('#text')
+      text.attributes.set('value', value)
+      this.appendChild(text)
+    }
+    this.events.push(`write:${value}`)
+  }
+
+  get innerHTML() {
+    return this.childNodes.map(node => `<${node.tagName}></${node.tagName}>`).join('')
+  }
+
+  set innerHTML(value: string) {
+    this.replaceChildren()
+    const tagName = value.includes('<iframe') ? 'iframe' : value.includes('<svg') ? 'svg' : undefined
+    if (tagName)
+      this.appendChild(this.ownerDocument.createElement(tagName))
+    this.events.push(`html:${value}`)
+  }
+
+  appendChild(node: TestElement) {
+    node.remove()
+    node.parentNode = this
+    this.childNodes.push(node)
+    return node
+  }
+
+  append(...nodes: TestElement[]) {
+    for (const node of nodes) this.appendChild(node)
+  }
+
+  removeChild(node: TestElement) {
+    const index = this.childNodes.indexOf(node)
+    if (index < 0) throw new Error('Node is not a child')
+    this.childNodes.splice(index, 1)
+    node.parentNode = null
+    return node
+  }
+
+  replaceChildren(...nodes: TestElement[]) {
+    for (const child of this.childNodes) child.parentNode = null
+    this.childNodes.splice(0)
+    this.append(...nodes)
+    this.events.push(`replace:${nodes.map(node => node.tagName).join(',')}`)
+  }
+
+  remove() {
+    if (!this.parentNode) return
+    const index = this.parentNode.childNodes.indexOf(this)
+    if (index >= 0) this.parentNode.childNodes.splice(index, 1)
+    this.parentNode = null
+  }
+
+  contains(candidate: TestElement): boolean {
+    return candidate === this || this.childNodes.some(child => child.contains(candidate))
+  }
+
+  querySelector(selector: string): TestElement | null {
+    const tagName = selector.toLowerCase()
+    for (const child of this.childNodes) {
+      if (child.tagName === tagName) return child
+      const descendant = child.querySelector(selector)
+      if (descendant) return descendant
+    }
+    return null
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value)
+  }
+
+  hasAttribute(name: string) {
+    return this.attributes.has(name)
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null
+  }
+
+  getBBox() {
+    return { x: 1, y: 2, width: 300, height: 200 }
+  }
+}
+
+class TestDocument {
+  readonly body: TestElement
+
+  constructor(private readonly events: string[]) {
+    this.body = new TestElement('body', this, events)
+  }
+
+  createElement(tagName: string) {
+    return new TestElement(tagName.toLowerCase(), this, this.events)
+  }
+}
+
+function createDomTarget(events: string[]) {
+  const document = new TestDocument(events)
+  const liveRoot = document.createElement('main')
+  const target = document.createElement('div')
+  const committed = document.createElement('svg')
+  committed.setAttribute('data-committed', 'true')
+  document.body.appendChild(liveRoot)
+  liveRoot.appendChild(target)
+  target.appendChild(committed)
+
+  return { document, liveRoot, target, committed }
+}
+
+describe('createMermaidRenderer', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
@@ -67,7 +153,7 @@ describe('createMermaidRenderer', () => {
 
     const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
     const loadMermaid = vi.fn()
-    const prepare = vi.fn()
+    const beforeCommit = vi.fn()
     const readRenderData = vi.fn(() => ({
       source: 'graph TD; A-->B',
       config: {} satisfies MermaidConfig,
@@ -77,24 +163,24 @@ describe('createMermaidRenderer', () => {
     const requestRender = createMermaidRenderer({
       loadMermaid,
       readRenderData,
-      prepare,
+      beforeCommit,
       debug: true,
     })
 
     expect(readRenderData).not.toHaveBeenCalled()
     expect(loadMermaid).not.toHaveBeenCalled()
-    expect(prepare).not.toHaveBeenCalled()
+    expect(beforeCommit).not.toHaveBeenCalled()
 
     await expect(requestRender()).resolves.toEqual({ status: 'skipped' })
     expect(readRenderData).toHaveBeenCalledOnce()
     expect(loadMermaid).not.toHaveBeenCalled()
-    expect(prepare).not.toHaveBeenCalled()
+    expect(beforeCommit).not.toHaveBeenCalled()
   })
 
-  it('skips an empty source before prepare or Mermaid loading', async () => {
+  it('skips an empty source before commit preparation or Mermaid loading', async () => {
     const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
     const loadMermaid = vi.fn()
-    const prepare = vi.fn()
+    const beforeCommit = vi.fn()
     const readRenderData = vi.fn(() => ({
       source: '',
       config: {} satisfies MermaidConfig,
@@ -104,51 +190,52 @@ describe('createMermaidRenderer', () => {
     const requestRender = createMermaidRenderer({
       loadMermaid,
       readRenderData,
-      prepare,
+      beforeCommit,
       debug: false,
     })
 
     await expect(requestRender()).resolves.toEqual({ status: 'skipped' })
     expect(loadMermaid).not.toHaveBeenCalled()
-    expect(prepare).not.toHaveBeenCalled()
+    expect(beforeCommit).not.toHaveBeenCalled()
   })
 
-  it('follows the valid Render Attempt protocol and normalizes the SVG viewBox', async () => {
+  it('stages a valid Render Attempt offscreen and commits it in one live replacement', async () => {
     const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
     const events: string[] = []
-    scheduler.events = events
     const config = { theme: 'dark' } satisfies MermaidConfig
-    const svg = {
-      hasAttribute: vi.fn((name: string) => {
-        events.push(`has:${name}`)
-        return false
-      }),
-      getBBox: vi.fn(() => {
-        events.push('bbox')
-        return { x: 1, y: 2, width: 300, height: 200 }
-      }),
-      setAttribute: vi.fn((name: string, value: string) => {
-        events.push(`set:${name}:${value}`)
-      }),
-    } as unknown as SVGSVGElement
-    const { target } = createTarget(events, svg)
+    const { document, liveRoot, target, committed } = createDomTarget(events)
+    let finishRender!: (value: { svg: string }) => void
+    const renderResult = new Promise<{ svg: string }>((resolve) => {
+      finishRender = resolve
+    })
     const mermaid = asMermaid({
       initialize: vi.fn((receivedConfig: MermaidConfig) => {
         expect(receivedConfig).toBe(config)
         events.push('initialize')
       }),
-      run: vi.fn(async (options) => {
-        expect(options).toEqual({ nodes: [target], suppressErrors: true })
-        events.push('run')
+      render: vi.fn(async (_id, source, stagingTarget) => {
+        expect(source).toBe('graph TD; A-->B')
+        expect(stagingTarget).not.toBe(target)
+        const stagingElement = stagingTarget as unknown as TestElement
+        const stagingRoot = stagingElement.parentNode
+        expect(stagingElement.isConnected).toBe(true)
+        expect(liveRoot.contains(stagingElement)).toBe(false)
+        expect(stagingRoot?.getAttribute('aria-hidden')).toBe('true')
+        expect(stagingRoot?.inert).toBe(true)
+        expect(stagingRoot?.tabIndex).toBe(-1)
+        expect(stagingRoot?.style.pointerEvents).toBe('none')
+        expect(stagingRoot?.style.opacity).toBe('0')
+        events.push('render')
+        return renderResult
       }),
     })
     const requestRender = createMermaidRenderer({
       readRenderData: () => {
         events.push('read')
-        return { source: 'graph TD; A-->B', config, target }
+        return { source: 'graph TD; A-->B', config, target: target as unknown as HTMLDivElement }
       },
-      prepare: () => {
-        events.push('prepare')
+      beforeCommit: () => {
+        events.push('beforeCommit')
       },
       loadMermaid: async () => {
         events.push('load')
@@ -157,118 +244,280 @@ describe('createMermaidRenderer', () => {
       debug: false,
     })
 
-    const outcome = await requestRender()
-    events.push(outcome.status)
+    const outcome = requestRender()
+    await vi.waitFor(() => expect(mermaid.render).toHaveBeenCalledOnce())
+    expect(target.childNodes).toEqual([committed])
 
-    expect(events).toEqual([
-      'read',
-      'prepare',
-      'load',
-      'initialize',
-      'remove:data-processed',
-      'write:graph TD; A-->B',
-      'scheduler',
-      'run',
-      'query:svg',
-      'has:viewBox',
-      'bbox',
-      'set:viewBox:1 2 300 200',
-      'success',
-    ])
+    finishRender({ svg: '<svg data-staged="true"></svg>' })
+    await expect(outcome).resolves.toEqual({ status: 'success' })
+
+    expect(target.childNodes.map(node => node.tagName)).toEqual(['svg'])
+    expect(target.childNodes[0]).not.toBe(committed)
+    expect(events.indexOf('beforeCommit')).toBeLessThan(events.lastIndexOf('replace:svg'))
+    expect(document.body.childNodes).toEqual([liveRoot])
   })
 
-  it('shares one FIFO and reads each requester data only when dequeued', async () => {
+  it.each([
+    ['strict SVG', '<svg data-security="strict"></svg>', 'svg'],
+    ['sandbox iframe', '<iframe data-security="sandbox"></iframe>', 'iframe'],
+  ])('moves committed %s nodes from staging without reparsing', async (_label, output, expectedTag) => {
     const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
     const events: string[] = []
-    let releaseFirst!: () => void
-    let markFirstStarted!: () => void
-    const firstStarted = new Promise<void>((resolve) => {
-      markFirstStarted = resolve
-    })
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve
-    })
-    const firstTarget = createTarget(events).target
-    const oldTarget = createTarget(events)
-    const latestTarget = createTarget(events)
-    const oldConfig = { theme: 'default' } satisfies MermaidConfig
-    const latestConfig = { theme: 'forest' } satisfies MermaidConfig
-    let secondData = {
-      source: 'old source',
-      config: oldConfig as MermaidConfig,
-      target: oldTarget.target,
-    }
-
-    const firstRequester = createMermaidRenderer({
-      readRenderData: () => ({ source: 'first source', config: {}, target: firstTarget }),
-      prepare: () => {},
+    const { target } = createDomTarget(events)
+    let boundNode: TestElement | undefined
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => ({
+        source: 'source',
+        config: {},
+        target: target as unknown as HTMLDivElement,
+      }),
+      beforeCommit: () => {},
       loadMermaid: async () => asMermaid({
         initialize: vi.fn(),
-        run: vi.fn(async () => {
-          events.push('first:start')
-          markFirstStarted()
-          await firstGate
-          events.push('first:finish')
-        }),
-      }),
-      debug: false,
-    })
-    const secondRead = vi.fn(() => secondData)
-    const secondInitialize = vi.fn()
-    const secondRequester = createMermaidRenderer({
-      readRenderData: secondRead,
-      prepare: () => {},
-      loadMermaid: async () => asMermaid({
-        initialize: secondInitialize,
-        run: vi.fn(async () => {
-          events.push('second')
-        }),
+        render: vi.fn(async () => ({
+          svg: output,
+          bindFunctions: (stagingTarget: Element) => {
+            boundNode = (stagingTarget as unknown as TestElement).childNodes[0]
+          },
+        })),
       }),
       debug: false,
     })
 
-    const firstOutcome = firstRequester()
-    await firstStarted
-    const secondOutcome = secondRequester()
-    secondData = {
-      source: 'latest source',
-      config: latestConfig,
-      target: latestTarget.target,
-    }
-
-    await Promise.resolve()
-    expect(secondRead).not.toHaveBeenCalled()
-
-    releaseFirst()
-    await expect(Promise.all([firstOutcome, secondOutcome])).resolves.toEqual([
-      { status: 'success' },
-      { status: 'success' },
-    ])
-    expect(events.indexOf('first:finish')).toBeLessThan(events.indexOf('second'))
-    expect(secondInitialize).toHaveBeenCalledWith(latestConfig)
-    expect(oldTarget.readContent()).toBe('')
-    expect(latestTarget.readContent()).toBe('latest source')
+    await expect(requestRender()).resolves.toEqual({ status: 'success' })
+    expect(target.childNodes).toEqual([boundNode])
+    expect(target.childNodes[0]?.tagName).toBe(expectedTag)
   })
 
-  it('preserves failures from every attempt stage, clears the target, and recovers the FIFO', async () => {
+  it('skips a stale queued Render Request before reading data or loading Mermaid', async () => {
     const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
-    const stages = ['prepare', 'loader', 'initialize', 'run', 'normalization'] as const
+    const events: string[] = []
+    let releaseBlocker!: (value: { svg: string }) => void
+    let markBlockerStarted!: () => void
+    const blockerStarted = new Promise<void>((resolve) => {
+      markBlockerStarted = resolve
+    })
+    const blockerGate = new Promise<{ svg: string }>((resolve) => {
+      releaseBlocker = resolve
+    })
+    const blockerTarget = createDomTarget(events).target
+    const latestTarget = createDomTarget(events).target
+
+    const blockerRequester = createMermaidRenderer({
+      readRenderData: () => ({ source: 'blocker source', config: {}, target: blockerTarget as unknown as HTMLDivElement }),
+      beforeCommit: () => {},
+      loadMermaid: async () => asMermaid({
+        initialize: vi.fn(),
+        render: vi.fn(async () => {
+          markBlockerStarted()
+          return blockerGate
+        }),
+      }),
+      debug: false,
+    })
+    const readRenderData = vi.fn(() => ({
+      source: 'latest source',
+      config: { theme: 'forest' } satisfies MermaidConfig,
+      target: latestTarget as unknown as HTMLDivElement,
+    }))
+    const initialize = vi.fn()
+    const render = vi.fn(async () => ({ svg: '<svg data-source="latest"></svg>' }))
+    const loadMermaid = vi.fn(async () => asMermaid({ initialize, render }))
+    const requestRender = createMermaidRenderer({
+      readRenderData,
+      beforeCommit: () => {},
+      loadMermaid,
+      debug: false,
+    })
+
+    const blockerOutcome = blockerRequester()
+    await blockerStarted
+    const staleOutcome = requestRender()
+    const latestOutcome = requestRender()
+
+    releaseBlocker({ svg: '<svg></svg>' })
+    await expect(Promise.all([blockerOutcome, staleOutcome, latestOutcome])).resolves.toEqual([
+      { status: 'success' },
+      { status: 'stale' },
+      { status: 'success' },
+    ])
+    expect(readRenderData).toHaveBeenCalledOnce()
+    expect(loadMermaid).toHaveBeenCalledOnce()
+    expect(initialize).toHaveBeenCalledOnce()
+    expect(render).toHaveBeenCalledOnce()
+  })
+
+  it('discards an executing Render Attempt that becomes stale before commit', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const events: string[] = []
+    const { target, committed } = createDomTarget(events)
+    let source = 'old source'
+    let finishOld!: (value: { svg: string }) => void
+    let finishLatest!: (value: { svg: string }) => void
+    const oldGate = new Promise<{ svg: string }>((resolve) => {
+      finishOld = resolve
+    })
+    const latestGate = new Promise<{ svg: string }>((resolve) => {
+      finishLatest = resolve
+    })
+    const render = vi.fn()
+      .mockImplementationOnce(async () => oldGate)
+      .mockImplementationOnce(async () => latestGate)
+    const beforeCommit = vi.fn()
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => ({
+        source,
+        config: {},
+        target: target as unknown as HTMLDivElement,
+      }),
+      beforeCommit,
+      loadMermaid: async () => asMermaid({ initialize: vi.fn(), render }),
+      debug: false,
+    })
+
+    const staleOutcome = requestRender()
+    await vi.waitFor(() => expect(render).toHaveBeenCalledOnce())
+    source = 'latest source'
+    const latestOutcome = requestRender()
+
+    finishOld({ svg: '<svg data-source="old"></svg>' })
+    await expect(staleOutcome).resolves.toEqual({ status: 'stale' })
+    expect(beforeCommit).not.toHaveBeenCalled()
+    expect(target.childNodes).toEqual([committed])
+
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2))
+    finishLatest({ svg: '<svg data-source="latest"></svg>' })
+    await expect(latestOutcome).resolves.toEqual({ status: 'success' })
+    expect(beforeCommit).toHaveBeenCalledOnce()
+    expect(target.childNodes[0]).not.toBe(committed)
+  })
+
+  it('classifies a failure from an invalidated Render Attempt as stale', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const events: string[] = []
+    const { target, committed } = createDomTarget(events)
+    const staleFailure = new Error('stale failure')
+    let rejectStale!: (reason: unknown) => void
+    let finishLatest!: (value: { svg: string }) => void
+    const staleGate = new Promise<{ svg: string }>((_resolve, reject) => {
+      rejectStale = reject
+    })
+    const latestGate = new Promise<{ svg: string }>((resolve) => {
+      finishLatest = resolve
+    })
+    const render = vi.fn()
+      .mockImplementationOnce(async () => staleGate)
+      .mockImplementationOnce(async () => latestGate)
+    const beforeCommit = vi.fn()
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => ({
+        source: 'source',
+        config: {},
+        target: target as unknown as HTMLDivElement,
+      }),
+      beforeCommit,
+      loadMermaid: async () => asMermaid({ initialize: vi.fn(), render }),
+      debug: false,
+    })
+
+    const staleOutcome = requestRender()
+    await vi.waitFor(() => expect(render).toHaveBeenCalledOnce())
+    const latestOutcome = requestRender()
+    rejectStale(staleFailure)
+
+    await expect(staleOutcome).resolves.toEqual({ status: 'stale' })
+    expect(target.childNodes).toEqual([committed])
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2))
+    finishLatest({ svg: '<svg data-source="latest"></svg>' })
+    await expect(latestOutcome).resolves.toEqual({ status: 'success' })
+    expect(beforeCommit).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to parent removal when staging root cleanup throws', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const events: string[] = []
+    const { document, liveRoot, target } = createDomTarget(events)
+    const originalCreateElement = document.createElement.bind(document)
+    let stagingRoot: TestElement | undefined
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName)
+      if (!stagingRoot) {
+        stagingRoot = element
+        const remove = element.remove.bind(element)
+        element.remove = () => {
+          if (element.isConnected) throw new Error('cleanup failed')
+          remove()
+        }
+      }
+      return element
+    })
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => ({
+        source: 'source',
+        config: {},
+        target: target as unknown as HTMLDivElement,
+      }),
+      beforeCommit: () => {},
+      loadMermaid: async () => asMermaid({
+        initialize: vi.fn(),
+        render: vi.fn(async () => ({ svg: '<svg></svg>' })),
+      }),
+      debug: false,
+    })
+
+    await expect(requestRender()).resolves.toEqual({ status: 'success' })
+    expect(stagingRoot?.parentNode).toBeNull()
+    expect(document.body.childNodes).toEqual([liveRoot])
+  })
+
+  it('logically invalidates an executing Render Attempt without physical cancellation', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const events: string[] = []
+    const { target, committed } = createDomTarget(events)
+    let finishRender!: (value: { svg: string }) => void
+    const renderGate = new Promise<{ svg: string }>((resolve) => {
+      finishRender = resolve
+    })
+    const beforeCommit = vi.fn()
+    const render = vi.fn(async () => renderGate)
+    const requestRender = createMermaidRenderer({
+      readRenderData: () => ({
+        source: 'source',
+        config: {},
+        target: target as unknown as HTMLDivElement,
+      }),
+      beforeCommit,
+      loadMermaid: async () => asMermaid({ initialize: vi.fn(), render }),
+      debug: false,
+    })
+
+    const outcome = requestRender()
+    await vi.waitFor(() => expect(render).toHaveBeenCalledOnce())
+    requestRender.invalidate()
+    finishRender({ svg: '<svg></svg>' })
+
+    await expect(outcome).resolves.toEqual({ status: 'stale' })
+    expect(beforeCommit).not.toHaveBeenCalled()
+    expect(target.childNodes).toEqual([committed])
+  })
+
+  it('preserves the Committed Diagram and cleans staging after every failure stage', async () => {
+    const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
+    const stages = ['loader', 'initialize', 'render', 'binding', 'beforeCommit'] as const
 
     for (const stage of stages) {
       const events: string[] = []
       const thrownValue = { stage }
-      const { target } = createTarget(events)
-
-      if (stage === 'normalization') {
-        target.querySelector = vi.fn(() => {
-          throw thrownValue
-        })
-      }
+      const { document, liveRoot, target, committed } = createDomTarget(events)
 
       const requestRender = createMermaidRenderer({
-        readRenderData: () => ({ source: `${stage} source`, config: {}, target }),
-        prepare: () => {
-          if (stage === 'prepare') throw thrownValue
+        readRenderData: () => ({
+          source: `${stage} source`,
+          config: {},
+          target: target as unknown as HTMLDivElement,
+        }),
+        beforeCommit: () => {
+          if (stage === 'beforeCommit') throw thrownValue
         },
         loadMermaid: async () => {
           if (stage === 'loader') throw thrownValue
@@ -277,8 +526,14 @@ describe('createMermaidRenderer', () => {
             initialize: vi.fn(() => {
               if (stage === 'initialize') throw thrownValue
             }),
-            run: vi.fn(async () => {
-              if (stage === 'run') throw thrownValue
+            render: vi.fn(async () => {
+              if (stage === 'render') throw thrownValue
+              return {
+                svg: '<svg></svg>',
+                bindFunctions: () => {
+                  if (stage === 'binding') throw thrownValue
+                },
+              }
             }),
           })
         },
@@ -290,25 +545,33 @@ describe('createMermaidRenderer', () => {
       expect(outcome.status).toBe('failure')
       if (outcome.status === 'failure')
         expect(outcome.error).toBe(thrownValue)
-      expect(events).toContain('html:')
+      expect(target.childNodes).toEqual([committed])
+      expect(document.body.childNodes).toEqual([liveRoot])
     }
 
-    const recoveredTarget = createTarget([])
+    const recoveredTarget = createDomTarget([])
     const recoveredRequest = createMermaidRenderer({
-      readRenderData: () => ({ source: 'recovered', config: {}, target: recoveredTarget.target }),
-      prepare: () => {},
-      loadMermaid: async () => asMermaid({ initialize: vi.fn(), run: vi.fn() }),
+      readRenderData: () => ({
+        source: 'recovered',
+        config: {},
+        target: recoveredTarget.target as unknown as HTMLDivElement,
+      }),
+      beforeCommit: () => {},
+      loadMermaid: async () => asMermaid({
+        initialize: vi.fn(),
+        render: vi.fn(async () => ({ svg: '<svg></svg>' })),
+      }),
       debug: false,
     })
 
     await expect(recoveredRequest()).resolves.toEqual({ status: 'success' })
-    expect(recoveredTarget.readContent()).toBe('recovered')
+    expect(recoveredTarget.target.childNodes[0]).not.toBe(recoveredTarget.committed)
   })
 
   it('reports debug diagnostics by semantic event category', async () => {
     const { createMermaidRenderer } = await import('../src/runtime/mermaid-rendering')
     const thrownValue = new Error('debug failure')
-    const { target } = createTarget([])
+    const { target } = createDomTarget([])
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.stubGlobal('performance', {
@@ -317,11 +580,15 @@ describe('createMermaidRenderer', () => {
         .mockReturnValueOnce(125),
     })
     const requestRender = createMermaidRenderer({
-      readRenderData: () => ({ source: 'debug source', config: {}, target }),
-      prepare: () => {},
+      readRenderData: () => ({
+        source: 'debug source',
+        config: {},
+        target: target as unknown as HTMLDivElement,
+      }),
+      beforeCommit: () => {},
       loadMermaid: async () => asMermaid({
         initialize: vi.fn(),
-        run: vi.fn(async () => {
+        render: vi.fn(async () => {
           throw thrownValue
         }),
       }),


### PR DESCRIPTION
Closes #24

## Summary

- assign every Built-in Renderer request to a component-local render generation
- render through a document-connected, inaccessible offscreen staging host outside the live subtree
- commit strict SVG and sandbox iframe output with one synchronous live-target replacement
- preserve the latest committed diagram and package-managed presentation state across stale, invalidated, and failed work
- use the error-propagating `mermaid.render()` API and always remove staging hosts

## Transactional invariants

- stale queued work may be skipped; already executing stale work may finish only in staging and is discarded
- the last generation eligibility check happens before a non-yielding synchronous commit phase
- only the latest successful generation may close overlay/fullscreen, clear error state, mark first render, or replace live DOM
- staging remains connected only for Mermaid layout measurement, with `aria-hidden`, `inert`, and disabled pointer interaction, and is removed in `finally`
- failures retain the prior committed diagram and propagate their original error outcome

## Scope boundaries

- no public physical-cancellation or `AbortSignal` contract
- no public promise about queue organization or implementation
- no #23 descriptor-safe configuration work and no #30 configuration-conflict orchestration

## Verification

- `pnpm exec vitest run test/mermaidRendering.test.ts` — 12 passed
- `pnpm exec vitest run test/builtInRenderer.e2e.test.ts` — 7 passed
- `pnpm exec vitest run test/expandToolbar.e2e.test.ts` — 3 passed
- related browser fixtures (`colorMode`, `customComponents`, `customRenderer`) — passed
- `pnpm prepack` — passed
- `pnpm lint` — passed
- `pnpm test:types` — passed
- `pnpm test` — 18 files, 130 tests passed

## Integration

Rebased onto `origin/main` at `99bbf8c`, after #23 merged. The two changes have no overlapping production or test files and no cross-imports; focused browser/renderer checks and the full suite passed after the rebase.