### PR TITLE
feat: resolve module activation and runtime transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,36 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  module-compatibility:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        nuxt-version: ['3.20.1', '4.1.0']
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - run: npm i -g --force corepack@latest && corepack enable
+
+      - name: Select the supported Nuxt line
+        run: >-
+          pnpm pkg set
+          devDependencies.nuxt=${{ matrix.nuxt-version }}
+          devDependencies.@nuxt/schema=${{ matrix.nuxt-version }}
+          dependencies.@nuxt/kit=${{ matrix.nuxt-version }}
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Prepare Nuxt types and module stubs
+        run: pnpm dev:prepare
+
+      - name: Verify canonical module configuration fixture
+        run: pnpm vitest run test/moduleConfiguration.e2e.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,5 @@ jobs:
       - name: Prepare Nuxt types and module stubs
         run: pnpm dev:prepare
 
-      - name: Verify canonical module configuration fixture
-        run: pnpm vitest run test/moduleConfiguration.e2e.test.ts
+      - name: Verify module configuration fixtures
+        run: pnpm vitest run test/moduleConfiguration.e2e.test.ts test/moduleConfigurationMigration.e2e.test.ts

--- a/docs/superpowers/plans/2026-08-03-module-activation-transport.md
+++ b/docs/superpowers/plans/2026-08-03-module-activation-transport.md
@@ -1,0 +1,354 @@
+# Module Activation and Runtime Transport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `contentMermaid` the sole module configuration path, resolve build-time activation independently from a canonical pure-data runtime transport, and install integration only for a validated enabled module.
+
+**Architecture:** A new pure `src/configuration/module.ts` receives only Nuxt-resolved options and canonical public-runtime overrides. It validates descriptor-safely, resolves internal defaults through named activation and transport resolvers, and returns `{ enabled, runtimeOptions }`. `src/module.ts` performs legacy-key preflight and complete resolution before activation and side effects; enabled setup atomically publishes the sole transport before installing current integration.
+
+**Tech Stack:** Nuxt Kit, TypeScript ESM, Vitest, existing descriptor-safe configuration core, pnpm, GitHub Actions.
+
+## Global Constraints
+
+- Support Nuxt `^3.20.1 || ^4.1.0`; do not use Nuxt 4.3-only native module-disable syntax.
+- `defineNuxtModule.defaults` is omitted or empty; complete defaults remain private to the resolver.
+- Use property descriptors for every application-owned diagnostic; never invoke getters, setters, or serialization hooks.
+- Runtime transport accepts only strict pure data and never includes `enabled`; the build-time output is owned but not frozen.
+- Merge exactly package defaults → Nuxt-resolved options → `runtimeConfig.public.contentMermaid`; arrays, `null`, and every explicit falsy value replace lower values.
+- `mermaidContent` is a removed top-level Nuxt key: its own-property presence fails before integration is installed. The runtime alias is never read, written, removed, or used as a fallback.
+- Disabled setup still completes preflight and configuration validation, then changes neither public runtime config nor CSS, Vite plugins, components, imports, type templates, plugins, or Markdown hooks.
+- Preserve the existing public `$mermaid`, component, styling, lazy-loading, and theme contracts; Runtime Mermaid Snapshot work is ticket #26 and out of scope.
+
+---
+
+### Task 1: Define the public module-resolution seam and its red tests
+
+**Files:**
+- Create: `test/moduleConfiguration.test.ts`
+- Test: `test/package-contract/v3-configuration.ts` (existing runtime-only and removed-alias assertions)
+
+**Interfaces:**
+- Consumes: `RuntimeOptions`, `ModuleOptions`, and pure-data types from `src/types/config.ts`.
+- Produces: an internal test contract for `resolveModuleConfiguration(input: { nuxtResolvedOptions: unknown; runtimeOverrides: unknown }): { enabled: boolean; runtimeOptions: RuntimeOptions }` without making the resolver a package-root export.
+
+- [ ] **Step 1: Add failing resolver tests for precedence and activation separation**
+
+```ts
+it('merges defaults, Nuxt options, then runtime overrides without transporting enabled', () => {
+  const result = resolveModuleConfiguration({
+    nuxtResolvedOptions: { enabled: false, toolbar: { title: 'Nuxt' }, expand: false },
+    runtimeOverrides: { toolbar: { title: '' }, expand: { margin: 24 }, debug: false },
+  })
+
+  expect(result.enabled).toBe(false)
+  expect(result.runtimeOptions).toMatchObject({
+    debug: false,
+    toolbar: { title: '' },
+    expand: { enabled: false, margin: 24 },
+  })
+  expect(result.runtimeOptions).not.toHaveProperty('enabled')
+})
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails because the resolver is absent**
+
+Run: `pnpm vitest run test/moduleConfiguration.test.ts`
+
+Expected: FAIL with a module-not-found or missing-export error for `src/configuration/module.ts`.
+
+- [ ] **Step 3: Confirm the existing package-user type assertions cover the public transport boundary**
+
+```ts
+// @ts-expect-error activation is not available in runtime transport
+void resolvedPublicRuntimeConfig.contentMermaid?.enabled
+```
+
+- [ ] **Step 4: Run the package contract check to establish the current public boundary**
+
+Run: `pnpm test:package-contract`
+
+Expected: PASS; the resolver remains an internal source-module seam, and the existing contract keeps `enabled` outside `PublicRuntimeConfig`.
+
+### Task 2: Implement the pure descriptor-safe Module Configuration Resolver
+
+**Files:**
+- Create: `src/configuration/module.ts`
+- Modify: `src/types/config.ts`
+- Modify: `test/moduleConfiguration.test.ts`
+
+**Interfaces:**
+- Consumes: `assertStrictData`, `cloneOwnedData`, `mergeByPresence`, and `ContentMermaidConfigurationError` from `src/configuration/core.ts`.
+- Produces: `resolveModuleConfiguration` as the sole exported resolver function; named private `resolveModuleActivation` and `resolveRuntimeTransport` helpers.
+
+- [ ] **Step 1: Add failing tests for all raw and final validation obligations**
+
+```ts
+it('rejects a runtime enabled property before activation is considered', () => {
+  expect(() => resolveModuleConfiguration({
+    nuxtResolvedOptions: { enabled: false },
+    runtimeOverrides: { enabled: false },
+  })).toMatchObject({
+    name: 'ContentMermaidConfigurationError',
+    code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+  })
+})
+
+it('diagnoses accessors without executing them', () => {
+  let calls = 0
+  const runtimeOverrides = {}
+  Object.defineProperty(runtimeOverrides, 'debug', {
+    enumerable: true,
+    get: () => { calls += 1; return true },
+  })
+
+  expect(() => resolveModuleConfiguration({ nuxtResolvedOptions: {}, runtimeOverrides })).toThrow()
+  expect(calls).toBe(0)
+})
+```
+
+Include cases for invalid activation type, open Mermaid configuration preservation, explicit `null`, `0`, `false`, `''`, and `[]`, source immutability, owned mutable output, and a final invalid value produced by a malformed layer.
+
+- [ ] **Step 2: Run the focused resolver tests and verify the newly added cases fail**
+
+Run: `pnpm vitest run test/moduleConfiguration.test.ts`
+
+Expected: FAIL only for unimplemented resolver behavior; record each failure before production code is added.
+
+- [ ] **Step 3: Implement private defaults and named resolver functions**
+
+```ts
+export interface ModuleConfigurationInput {
+  readonly nuxtResolvedOptions: unknown
+  readonly runtimeOverrides: unknown
+}
+
+export interface ResolvedModuleConfiguration {
+  readonly enabled: boolean
+  readonly runtimeOptions: RuntimeOptions
+}
+
+export function resolveModuleConfiguration(
+  input: ModuleConfigurationInput,
+): ResolvedModuleConfiguration {
+  // validate both raw application-owned layers before extracting data
+  // resolve activation from package defaults + Nuxt options only
+  // reject own runtime `enabled`; merge the three transport layers in order
+  // validate final transport, clone it, and return a mutable owned RuntimeOptions
+}
+```
+
+Keep package defaults strict-pure-data by omitting optional component values instead of assigning `undefined`. Use descriptor extraction rather than spreads or `Object.entries` on application-owned inputs. Make package-owned envelopes closed, retaining unknown keys only below Mermaid-owned `loader.init`.
+
+- [ ] **Step 4: Run focused resolver and type-contract checks to verify green**
+
+Run: `pnpm vitest run test/moduleConfiguration.test.ts && pnpm test:package-contract`
+
+Expected: PASS; resolver behavior is covered without exporting diagnostics or resolver internals from the package root.
+
+- [ ] **Step 5: Commit the resolver slice**
+
+```bash
+git add src/configuration/module.ts src/types/config.ts test/moduleConfiguration.test.ts test/package-contract/v3-configuration.ts
+git commit -m "feat: resolve module activation and runtime transport"
+```
+
+### Task 3: Make setup a canonical alias-preflight and activation transaction
+
+**Files:**
+- Modify: `src/module.ts`
+- Modify: `test/moduleSetup.test.ts`
+- Modify: `src/runtime/plugins/mermaid.client.ts`
+- Modify: `src/runtime/components/Mermaid.vue`
+
+**Interfaces:**
+- Consumes: `resolveModuleConfiguration` and its returned `enabled` and `runtimeOptions`.
+- Produces: setup that writes only `runtimeConfig.public.contentMermaid` after validated enabled resolution; runtime consumers that consume only canonical runtime options.
+
+- [ ] **Step 1: Extend module-setup tests with failing preflight and transaction assertions**
+
+```ts
+it('fails for an own legacy alias without invoking its getter or registering integration', async () => {
+  let calls = 0
+  Object.defineProperty(nuxt.options, 'mermaidContent', {
+    enumerable: true,
+    get: () => { calls += 1; return undefined },
+  })
+
+  await expect(moduleDef.setup?.({}, nuxt)).rejects.toMatchObject({
+    name: 'ContentMermaidConfigurationError',
+    code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+  })
+  expect(calls).toBe(0)
+  expect(addPlugin).not.toHaveBeenCalled()
+  expect(nuxt.options.runtimeConfig.public).toEqual({})
+})
+
+it('leaves runtime config and every integration point untouched when disabled', async () => {
+  const before = { retained: { value: true } }
+  nuxt.options.runtimeConfig.public = before
+  await moduleDef.setup?.({ enabled: false }, nuxt)
+  expect(nuxt.options.runtimeConfig.public).toBe(before)
+  expect(addImports).not.toHaveBeenCalled()
+  expect(hooks).toEqual({})
+})
+```
+
+Add enabled assertions that runtime transport is owned, has no `enabled`, keeps no `mermaidContent` mirror, and is written before any registration calls. Add a runtime-alias sentinel getter to prove module setup does not read it.
+
+- [ ] **Step 2: Run module-setup tests and verify the new cases fail under the legacy implementation**
+
+Run: `pnpm vitest run test/moduleSetup.test.ts`
+
+Expected: FAIL because setup currently reads/warns on the alias, installs defaults through Nuxt, and mirrors legacy transport.
+
+- [ ] **Step 3: Replace legacy resolution in `src/module.ts` with preflight, resolver, and gate**
+
+```ts
+setup(options, nuxt) {
+  assertNoLegacyModuleAlias(nuxt.options)
+  const resolved = resolveModuleConfiguration({
+    nuxtResolvedOptions: options,
+    runtimeOverrides: nuxt.options.runtimeConfig.public.contentMermaid,
+  })
+
+  if (!resolved.enabled) return
+
+  nuxt.options.runtimeConfig.public.contentMermaid = resolved.runtimeOptions
+  // Existing CSS, Vite, plugin, component, import, type-template, and hook registration follows.
+}
+```
+
+Remove `defu`, module-level complete `defaults`, logger deprecation warnings, all `mermaidContent` reads/writes, and `enabled` runtime checks. Use an own-descriptor preflight on `nuxt.options` so even `undefined` and accessor aliases fail. Update plugin/component input types from `ModuleOptions` to `RuntimeOptions` and consume only `public.contentMermaid`.
+
+- [ ] **Step 4: Run narrow setup and runtime-consumer tests to verify green**
+
+Run: `pnpm vitest run test/moduleSetup.test.ts test/mermaidClientDebug.test.ts`
+
+Expected: PASS; disabled setup has zero setup side effects and enabled setup exposes only canonical runtime transport.
+
+- [ ] **Step 5: Commit the setup transaction slice**
+
+```bash
+git add src/module.ts src/runtime/plugins/mermaid.client.ts src/runtime/components/Mermaid.vue test/moduleSetup.test.ts test/mermaidClientDebug.test.ts
+git commit -m "feat: gate Nuxt integration by module activation"
+```
+
+### Task 4: Verify Nuxt fixtures and the declared Nuxt compatibility range
+
+**Files:**
+- Create: `test/fixtures/module-configuration/nuxt.config.ts`
+- Create: `test/fixtures/module-configuration/app.vue`
+- Create: `test/moduleConfiguration.e2e.test.ts`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: the package module exactly as a Package User configures it through `defineNuxtConfig`.
+- Produces: fixture-level evidence for enabled transport, disabled no-registration behavior, precedence, migration failure, and Nuxt 3/4 range execution.
+
+- [ ] **Step 1: Add failing Nuxt fixture scenarios**
+
+```ts
+it('renders the effective canonical public transport', async () => {
+  const html = await $fetch('/')
+  expect(html).toContain('runtime-config-sentinel')
+  expect(html).not.toContain('"enabled"')
+})
+
+it('rejects a fixture using the removed mermaidContent key before startup integration', async () => {
+  await expect(startLegacyFixture()).rejects.toMatchObject({
+    name: 'ContentMermaidConfigurationError',
+    code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+  })
+})
+```
+
+Make the enabled fixture set conflicting default/module/runtime fields (including array, `null`, and falsy replacements) and expose the resolved canonical transport using `useRuntimeConfig`. Keep a separate disabled fixture whose application proves no Mermaid component/plugin registration is present.
+
+- [ ] **Step 2: Run the fixture test and verify it fails before fixture implementation**
+
+Run: `pnpm vitest run test/moduleConfiguration.e2e.test.ts`
+
+Expected: FAIL because the fixture and canonical resolver integration do not yet exist.
+
+- [ ] **Step 3: Implement the fixtures and test only observable Package User behavior**
+
+```ts
+export default defineNuxtConfig({
+  modules: [contentMermaidModule],
+  contentMermaid: { toolbar: { title: 'Nuxt option' } },
+  runtimeConfig: { public: { contentMermaid: { toolbar: { title: '' } } } },
+})
+```
+
+Do not inspect private resolver functions from E2E tests. Keep mock-only scenarios in `test/moduleConfiguration.test.ts`.
+
+- [ ] **Step 4: Add CI compatibility matrix without changing tracked dependency manifests**
+
+```yaml
+strategy:
+  matrix:
+    nuxt-version: ['3.20.1', '4.1.0']
+steps:
+  - run: pnpm --config.overrides.nuxt=${{ matrix.nuxt-version }} install --no-frozen-lockfile
+  - run: pnpm vitest run test/moduleConfiguration.e2e.test.ts
+```
+
+Resolve matching `@nuxt/kit`, `@nuxt/schema`, and test-utils peer versions in the install command or an ephemeral CI override file so every matrix entry has compatible peers. Preserve the existing default CI jobs; this matrix is limited to the new module fixture contract.
+
+- [ ] **Step 5: Run the local fixture suite and verify green**
+
+Run: `pnpm vitest run test/moduleConfiguration.e2e.test.ts`
+
+Expected: PASS against the installed Nuxt line; CI runs the Nuxt `3.20.1` and `4.1.0` matrix.
+
+- [ ] **Step 6: Commit fixture and CI coverage**
+
+```bash
+git add test/fixtures/module-configuration test/moduleConfiguration.e2e.test.ts .github/workflows/ci.yml
+git commit -m "test: cover canonical module configuration"
+```
+
+### Task 5: Run the release-relevant checks and resolve review findings
+
+**Files:**
+- Modify only if verification or review reveals a task-scope defect.
+- Test: all affected tests plus repository lint, types, package build, and playground production build.
+
+**Interfaces:**
+- Consumes: all prior implementation slices.
+- Produces: verified branch ready for the required two-axis code review and pull request.
+
+- [ ] **Step 1: Run formatting/lint and repair only ticket-scoped findings**
+
+Run: `pnpm lint --fix && pnpm lint`
+
+Expected: PASS with no lint errors.
+
+- [ ] **Step 2: Run unit and type gates**
+
+Run: `pnpm test && pnpm test:types && pnpm test:package-contract`
+
+Expected: PASS; keep the full Vitest output as the test-suite evidence.
+
+- [ ] **Step 3: Run build gates**
+
+Run: `pnpm prepack && pnpm dev:build`
+
+Expected: PASS; do not commit generated `dist` artifacts.
+
+- [ ] **Step 4: Run whitespace and change-scope checks**
+
+Run: `git diff --check main...HEAD && git status --short && git diff --stat main...HEAD`
+
+Expected: no whitespace errors and only issue #25 implementation, tests, fixtures, CI, and plan/design files.
+
+- [ ] **Step 5: Perform the required `code-review` two-axis review against `main`**
+
+Use: `git diff main...HEAD` and Issue #25 as the specification source. Run independent Standards and Spec reviews, fix every actionable finding with focused tests, then rerun the affected verification commands.
+
+- [ ] **Step 6: Commit review fixes if needed**
+
+```bash
+git add <ticket-scoped-files>
+git commit -m "fix: address module configuration review findings"
+```

--- a/docs/superpowers/specs/2026-08-03-module-activation-transport-design.md
+++ b/docs/superpowers/specs/2026-08-03-module-activation-transport-design.md
@@ -1,0 +1,60 @@
+# Module activation and runtime transport design
+
+## Scope
+
+Implement GitHub issue #25. The module exposes `contentMermaid` as its only
+supported Nuxt configuration key. It resolves build-time activation separately
+from the public runtime transport and installs Nuxt integration only when
+activation succeeds and is enabled.
+
+## Ownership and inputs
+
+Nuxt Kit remains responsible for resolving inline module options and the
+`contentMermaid` config key. `defineNuxtModule.defaults` must not contain the
+package's complete defaults, so Nuxt does not erase explicit arrays, `null`, or
+falsy values before package-owned resolution.
+
+The package-owned resolver receives:
+
+1. package defaults;
+2. Nuxt-resolved module options; and
+3. build-time `runtimeConfig.public.contentMermaid` overrides.
+
+It observes each input through property descriptors and uses the existing
+strict-pure-data validation and Property-Presence Merge primitives. It neither
+reads getters nor triggers application-owned behavior while diagnosing input.
+
+## Resolver design
+
+`src/configuration/module.ts` will hold pure, named resolver functions:
+
+- `resolveModuleActivation` merges package defaults with Nuxt-resolved options
+  and returns the build-only `enabled` result.
+- `resolveRuntimeTransport` merges package defaults, Nuxt-resolved options, and
+  runtime overrides in that exact low-to-high order after excluding activation.
+- `resolveModuleConfiguration` coordinates the two results and returns a
+  frozen, package-owned runtime payload only after all validation succeeds.
+
+The resolver rejects `enabled` in runtime overrides. It also diagnoses the
+removed `mermaidContent` alias before any integration is registered. Errors use
+the existing public diagnostic fingerprint.
+
+## Module setup transaction
+
+`src/module.ts` first performs alias detection and resolution without installing
+CSS, plugins, components, imports, type templates, Vite plugins, or Markdown
+hooks. If activation is disabled, setup returns without mutating the runtime
+payload or registering integration. If enabled, setup writes exactly one
+`runtimeConfig.public.contentMermaid` payload and then installs the existing
+Nuxt integration. It never reads, writes, or falls back to `mermaidContent`.
+
+## Verification
+
+Focused module-resolver tests will demonstrate descriptor safety, fixed
+precedence, explicit replacement values, alias failure, rejection of runtime
+activation, and output ownership. Module-setup tests will prove that disabled
+setup installs no integrations and leaves runtime transport untouched, whereas
+enabled setup publishes only the canonical payload and installs all expected
+integration points. Type tests will preserve the removed alias and build-only
+activation contracts. The existing Nuxt fixture suite remains the compatibility
+check for the supported Nuxt 3/4 range.

--- a/docs/superpowers/specs/2026-08-03-module-activation-transport-design.md
+++ b/docs/superpowers/specs/2026-08-03-module-activation-transport-design.md
@@ -10,51 +10,125 @@ activation succeeds and is enabled.
 ## Ownership and inputs
 
 Nuxt Kit remains responsible for resolving inline module options and the
-`contentMermaid` config key. `defineNuxtModule.defaults` must not contain the
-package's complete defaults, so Nuxt does not erase explicit arrays, `null`, or
-falsy values before package-owned resolution.
+`contentMermaid` config key. `defineNuxtModule.defaults` is omitted or empty;
+all package defaults remain behind the package-owned resolver so Nuxt cannot
+backfill or otherwise erase explicit arrays, `null`, or falsy values before the
+package sees its canonical input.
 
-The package-owned resolver receives:
+Package defaults are themselves valid strict pure data. Optional properties are
+absent rather than present with `undefined` values.
 
-1. package defaults;
+The package-owned resolver applies these resolution layers:
+
+1. internal package defaults;
 2. Nuxt-resolved module options; and
 3. build-time `runtimeConfig.public.contentMermaid` overrides.
 
-It observes each input through property descriptors and uses the existing
-strict-pure-data validation and Property-Presence Merge primitives. It neither
-reads getters nor triggers application-owned behavior while diagnosing input.
+Only the two application-owned layers cross the resolver interface. Package
+defaults remain an implementation detail so callers cannot replace or reorder
+them.
+
+It validates every input before reading values from it. Application-owned input
+is observed through property descriptors, so validation and diagnostics never
+read getters, invoke setters, call serialization hooks, or trigger other
+application-owned behavior. Structural validation uses the existing strict
+pure-data primitive, while named resolvers own package-domain validation and use
+the existing Property-Presence Merge primitive.
 
 ## Resolver design
 
-`src/configuration/module.ts` will hold pure, named resolver functions:
+`src/configuration/module.ts` exposes one pure interface to callers and tests:
+
+```ts
+interface ModuleConfigurationInput {
+  nuxtResolvedOptions: unknown
+  runtimeOverrides: unknown
+}
+
+interface ResolvedModuleConfiguration {
+  enabled: boolean
+  runtimeOptions: RuntimeOptions
+}
+
+function resolveModuleConfiguration(
+  input: ModuleConfigurationInput,
+): ResolvedModuleConfiguration
+```
+
+Its implementation uses private, named resolvers:
 
 - `resolveModuleActivation` merges package defaults with Nuxt-resolved options
-  and returns the build-only `enabled` result.
+  and returns the build-only `enabled` result. An absent value falls back to the
+  package default; a present value must be a boolean.
 - `resolveRuntimeTransport` merges package defaults, Nuxt-resolved options, and
   runtime overrides in that exact low-to-high order after excluding activation.
-- `resolveModuleConfiguration` coordinates the two results and returns a
-  frozen, package-owned runtime payload only after all validation succeeds.
+- `resolveModuleConfiguration` coordinates validation and both internal
+  resolvers, then returns activation and a wholly package-owned runtime payload
+  only after every phase succeeds.
 
-The resolver rejects `enabled` in runtime overrides. It also diagnoses the
-removed `mermaidContent` alias before any integration is registered. Errors use
-the existing public diagnostic fingerprint.
+The runtime payload is an owned clone but remains mutable for Nuxt's build-time
+transport. Deep freezing belongs to the later Universal Runtime Adapter and its
+per-NuxtApp Runtime Mermaid Snapshot.
 
-## Module setup transaction
+The runtime override is rejected whenever its own `enabled` property is
+present, regardless of the property's value. Activation never participates in
+runtime precedence and is absent from the final transport. Package-owned closed
+fields receive domain validation; Mermaid-owned open payloads retain unknown
+strict-pure-data keys. The final merged transport is validated again before it
+is returned.
 
-`src/module.ts` first performs alias detection and resolution without installing
-CSS, plugins, components, imports, type templates, Vite plugins, or Markdown
-hooks. If activation is disabled, setup returns without mutating the runtime
-payload or registering integration. If enabled, setup writes exactly one
+All configuration failures expose the exact global fingerprint:
+
+- name: `ContentMermaidConfigurationError`
+- code: `CONTENT_MERMAID_CONFIGURATION_ERROR`
+
+Internal phase, issue, and path details remain non-public.
+
+## Removed alias preflight
+
+`src/module.ts` owns a descriptor-safe preflight for the removed top-level Nuxt
+configuration key. Presence of an own `mermaidContent` property on Nuxt options
+produces the migration error even when its value is `undefined` or implemented
+as an accessor; the accessor is never invoked.
+
+`runtimeConfig.public.mermaidContent` is not a supported resolver input. The
+module never reads, writes, removes, mirrors, or falls back to it; the package
+only owns the canonical `runtimeConfig.public.contentMermaid` transport.
+
+## Module setup preflight and activation gate
+
+`src/module.ts` first performs removed-alias preflight and complete configuration
+resolution without installing CSS, plugins, components, imports, type
+templates, Vite plugins, or Markdown hooks. Validation always completes before
+activation is acted upon, so disabled module options cannot hide an alias,
+invalid configuration, or a runtime activation override.
+
+If activation is disabled, setup returns without mutating public runtime config
+or registering integration. If enabled, setup writes exactly one resolved
 `runtimeConfig.public.contentMermaid` payload and then installs the existing
-Nuxt integration. It never reads, writes, or falls back to `mermaidContent`.
+Nuxt integration. The gate guarantees that configuration failures occur before
+integration installation; it does not claim rollback for unrelated failures
+during later Nuxt integration calls.
 
 ## Verification
 
-Focused module-resolver tests will demonstrate descriptor safety, fixed
-precedence, explicit replacement values, alias failure, rejection of runtime
-activation, and output ownership. Module-setup tests will prove that disabled
-setup installs no integrations and leaves runtime transport untouched, whereas
-enabled setup publishes only the canonical payload and installs all expected
-integration points. Type tests will preserve the removed alias and build-only
-activation contracts. The existing Nuxt fixture suite remains the compatibility
-check for the supported Nuxt 3/4 range.
+Focused tests exercise only the public `resolveModuleConfiguration` interface.
+They demonstrate descriptor safety, fixed precedence, explicit array, `null`,
+falsy, and empty-value replacement, activation type validation, rejection of
+runtime activation even when disabled, final transport validation, output
+ownership without build-time freezing, and absence of activation from
+transport.
+
+Module-setup tests prove property-presence alias failure, including `undefined`
+and accessor cases, before any integration mutation. Disabled setup separately
+asserts that CSS, plugins, components, imports, type additions, Vite plugins,
+Markdown hooks, and public runtime config remain untouched. Enabled setup
+publishes only the canonical package-owned payload and installs every expected
+integration point without mirroring the legacy key.
+
+Type tests preserve the removed alias and build-only activation contracts. Nuxt
+fixtures verify enabled and disabled behavior, precedence, migration failure,
+and transport output. The compatibility check runs those relevant fixtures in
+a dependency matrix covering the minimum supported Nuxt 3 (`3.20.1`) and Nuxt
+4 (`4.1.0`) lines rather than inferring range compatibility from one installed
+Nuxt version.

--- a/src/configuration/core.ts
+++ b/src/configuration/core.ts
@@ -15,9 +15,11 @@ export type ConfigurationIssueCode
     | 'NON_ENUMERABLE_PROPERTY'
     | 'NON_FINITE_NUMBER'
     | 'NON_PLAIN_OBJECT'
+    | 'INVALID_VALUE'
     | 'SPARSE_ARRAY_SLOT'
     | 'SYMBOL_KEY'
     | 'SYMBOL_VALUE'
+    | 'UNEXPECTED_PROPERTY'
     | 'UNDEFINED_VALUE'
 
 export interface ConfigurationIssue {

--- a/src/configuration/module.ts
+++ b/src/configuration/module.ts
@@ -1,0 +1,318 @@
+import {
+  ContentMermaidConfigurationError,
+  assertStrictData,
+  cloneOwnedData,
+  mergeByPresence,
+  type ConfigurationIssueCode,
+  type ConfigurationValidationPhase,
+} from './core'
+import {
+  DEFAULT_DARK_THEME,
+  DEFAULT_EXPAND_OPTIONS,
+  DEFAULT_LIGHT_THEME,
+  DEFAULT_MERMAID_CONFIG,
+  DEFAULT_TOOLBAR_OPTIONS,
+} from '../runtime/constants'
+import type { JsonObject, JsonValue, RuntimeMermaidConfig, RuntimeOptions } from '../types/config'
+
+export interface ModuleConfigurationInput {
+  readonly nuxtResolvedOptions: unknown
+  readonly runtimeOverrides: unknown
+}
+
+export interface ResolvedModuleConfiguration {
+  readonly enabled: boolean
+  readonly runtimeOptions: RuntimeOptions
+}
+
+const PACKAGE_RUNTIME_DEFAULTS = {
+  loader: {
+    init: DEFAULT_MERMAID_CONFIG as RuntimeMermaidConfig,
+    lazy: true,
+  },
+  theme: {
+    light: DEFAULT_LIGHT_THEME,
+    dark: DEFAULT_DARK_THEME,
+  },
+  components: {},
+  expand: DEFAULT_EXPAND_OPTIONS,
+  toolbar: DEFAULT_TOOLBAR_OPTIONS,
+} satisfies RuntimeOptions
+
+const PACKAGE_MODULE_DEFAULTS = {
+  enabled: true,
+  ...PACKAGE_RUNTIME_DEFAULTS,
+}
+
+const NUXT_OPTIONS_PHASE = {
+  name: 'Nuxt-Resolved Module Options',
+  root: 'contentMermaid',
+} as const
+
+const RUNTIME_OVERRIDES_PHASE = {
+  name: 'Runtime Mermaid Overrides',
+  root: 'runtimeConfig.public.contentMermaid',
+} as const
+
+const RUNTIME_TRANSPORT_PHASE = {
+  name: 'Resolved Runtime Mermaid Options',
+  root: 'runtimeConfig.public.contentMermaid',
+} as const
+
+const MODULE_OPTION_KEYS = new Set([
+  'enabled',
+  'debug',
+  'loader',
+  'theme',
+  'components',
+  'expand',
+  'toolbar',
+])
+
+const RUNTIME_OPTION_KEYS = new Set([...MODULE_OPTION_KEYS].filter(key => key !== 'enabled'))
+
+function throwConfigurationIssue(
+  phase: ConfigurationValidationPhase,
+  path: readonly string[],
+  code: ConfigurationIssueCode,
+  expected: string,
+  received: string,
+): never {
+  throw new ContentMermaidConfigurationError(phase, [{ path, code, expected, received }], false)
+}
+
+function assertPlainObject(
+  value: JsonValue,
+  phase: ConfigurationValidationPhase,
+): asserts value is JsonObject {
+  if (value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+    throwConfigurationIssue(phase, [], 'NON_PLAIN_OBJECT', 'a plain object', 'non-plain-object')
+  }
+}
+
+function assertKnownKeys(
+  value: JsonObject,
+  allowedKeys: ReadonlySet<string>,
+  phase: ConfigurationValidationPhase,
+  path: readonly string[] = [],
+): void {
+  for (const key of Object.keys(Object.getOwnPropertyDescriptors(value))) {
+    if (!allowedKeys.has(key)) {
+      throwConfigurationIssue(phase, [...path, key], 'UNEXPECTED_PROPERTY', 'a known configuration property', 'unknown-property')
+    }
+  }
+}
+
+function descriptorValue(value: JsonObject, key: string): JsonValue | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key)
+  return descriptor && 'value' in descriptor ? descriptor.value as JsonValue : undefined
+}
+
+function hasOwn(value: JsonObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function assertBooleanProperty(
+  value: JsonObject,
+  key: string,
+  phase: ConfigurationValidationPhase,
+  path: readonly string[],
+): void {
+  if (hasOwn(value, key) && typeof descriptorValue(value, key) !== 'boolean') {
+    throwConfigurationIssue(phase, [...path, key], 'INVALID_VALUE', 'a boolean', typeof descriptorValue(value, key))
+  }
+}
+
+function assertStringProperty(
+  value: JsonObject,
+  key: string,
+  phase: ConfigurationValidationPhase,
+  path: readonly string[],
+): void {
+  if (hasOwn(value, key) && typeof descriptorValue(value, key) !== 'string') {
+    throwConfigurationIssue(phase, [...path, key], 'INVALID_VALUE', 'a string', typeof descriptorValue(value, key))
+  }
+}
+
+function assertNumberProperty(
+  value: JsonObject,
+  key: string,
+  phase: ConfigurationValidationPhase,
+  path: readonly string[],
+): void {
+  if (hasOwn(value, key) && typeof descriptorValue(value, key) !== 'number') {
+    throwConfigurationIssue(phase, [...path, key], 'INVALID_VALUE', 'a number', typeof descriptorValue(value, key))
+  }
+}
+
+function assertObjectProperty(
+  value: JsonObject,
+  key: string,
+  phase: ConfigurationValidationPhase,
+  path: readonly string[],
+  allowedKeys?: ReadonlySet<string>,
+): JsonObject | undefined {
+  if (!hasOwn(value, key)) return undefined
+
+  const nested = descriptorValue(value, key)
+  if (nested === null || Array.isArray(nested) || typeof nested !== 'object') {
+    throwConfigurationIssue(phase, [...path, key], 'INVALID_VALUE', 'a plain object', nested === null ? 'null' : typeof nested)
+  }
+  assertPlainObject(nested, phase)
+  if (allowedKeys) assertKnownKeys(nested, allowedKeys, phase, [...path, key])
+  return nested
+}
+
+function validateRuntimeOptions(value: JsonObject, phase: ConfigurationValidationPhase): void {
+  assertKnownKeys(value, RUNTIME_OPTION_KEYS, phase)
+  assertBooleanProperty(value, 'debug', phase, [])
+
+  const loader = assertObjectProperty(value, 'loader', phase, [], new Set(['init', 'lazy']))
+  if (loader) {
+    const init = assertObjectProperty(loader, 'init', phase, ['loader'])
+    if (init) {
+      assertStringProperty(init, 'theme', phase, ['loader', 'init'])
+      assertBooleanProperty(init, 'suppressErrorRendering', phase, ['loader', 'init'])
+    }
+
+    if (hasOwn(loader, 'lazy')) {
+      const lazy = descriptorValue(loader, 'lazy')
+      if (typeof lazy !== 'boolean') {
+        if (lazy === null || Array.isArray(lazy) || typeof lazy !== 'object') {
+          throwConfigurationIssue(phase, ['loader', 'lazy'], 'INVALID_VALUE', 'a boolean or plain object', lazy === null ? 'null' : typeof lazy)
+        }
+        assertPlainObject(lazy, phase)
+        assertKnownKeys(lazy, new Set(['threshold']), phase, ['loader', 'lazy'])
+        assertNumberProperty(lazy, 'threshold', phase, ['loader', 'lazy'])
+      }
+    }
+  }
+
+  const theme = assertObjectProperty(value, 'theme', phase, [], new Set(['useColorModeTheme', 'light', 'dark']))
+  if (theme) {
+    assertBooleanProperty(theme, 'useColorModeTheme', phase, ['theme'])
+    assertStringProperty(theme, 'light', phase, ['theme'])
+    assertStringProperty(theme, 'dark', phase, ['theme'])
+  }
+
+  const components = assertObjectProperty(value, 'components', phase, [], new Set(['renderer', 'spinner', 'error']))
+  if (components) {
+    for (const key of ['renderer', 'spinner', 'error']) assertStringProperty(components, key, phase, ['components'])
+  }
+
+  if (hasOwn(value, 'expand')) {
+    const expand = descriptorValue(value, 'expand')
+    if (typeof expand !== 'boolean') {
+      if (expand === null || Array.isArray(expand) || typeof expand !== 'object') {
+        throwConfigurationIssue(phase, ['expand'], 'INVALID_VALUE', 'a boolean or plain object', expand === null ? 'null' : typeof expand)
+      }
+      assertPlainObject(expand, phase)
+      assertKnownKeys(expand, new Set(['enabled', 'margin', 'invokeOpenOn', 'invokeCloseOn']), phase, ['expand'])
+      assertBooleanProperty(expand, 'enabled', phase, ['expand'])
+      assertNumberProperty(expand, 'margin', phase, ['expand'])
+      const invokeOpenOn = assertObjectProperty(expand, 'invokeOpenOn', phase, ['expand'], new Set(['diagramClick']))
+      if (invokeOpenOn) assertBooleanProperty(invokeOpenOn, 'diagramClick', phase, ['expand', 'invokeOpenOn'])
+      const invokeCloseOn = assertObjectProperty(expand, 'invokeCloseOn', phase, ['expand'], new Set(['esc', 'wheel', 'swipe', 'overlayClick', 'closeButtonClick']))
+      if (invokeCloseOn) {
+        for (const key of ['esc', 'wheel', 'swipe', 'overlayClick', 'closeButtonClick']) {
+          assertBooleanProperty(invokeCloseOn, key, phase, ['expand', 'invokeCloseOn'])
+        }
+      }
+    }
+  }
+
+  const toolbar = assertObjectProperty(value, 'toolbar', phase, [], new Set(['title', 'fontSize', 'fullscreenToolbarScale', 'buttons']))
+  if (toolbar) {
+    assertStringProperty(toolbar, 'title', phase, ['toolbar'])
+    if (hasOwn(toolbar, 'fontSize')) {
+      const fontSize = descriptorValue(toolbar, 'fontSize')
+      if (typeof fontSize !== 'string' && typeof fontSize !== 'number') {
+        throwConfigurationIssue(phase, ['toolbar', 'fontSize'], 'INVALID_VALUE', 'a string or number', typeof fontSize)
+      }
+    }
+    assertNumberProperty(toolbar, 'fullscreenToolbarScale', phase, ['toolbar'])
+    const buttons = assertObjectProperty(toolbar, 'buttons', phase, ['toolbar'], new Set(['copy', 'fullscreen', 'expand']))
+    if (buttons) {
+      for (const key of ['copy', 'fullscreen', 'expand']) assertBooleanProperty(buttons, key, phase, ['toolbar', 'buttons'])
+    }
+  }
+}
+
+function validateModuleOptions(value: JsonObject, phase: ConfigurationValidationPhase): void {
+  assertKnownKeys(value, MODULE_OPTION_KEYS, phase)
+  assertBooleanProperty(value, 'enabled', phase, [])
+
+  const runtimeOptions = cloneOwnedData(value)
+  delete runtimeOptions.enabled
+  validateRuntimeOptions(runtimeOptions, phase)
+}
+
+function validateRawLayer(value: unknown, phase: ConfigurationValidationPhase, moduleOptions: boolean): JsonObject {
+  if (value === undefined) return {}
+
+  assertStrictData(value, phase)
+  assertPlainObject(value, phase)
+  if (moduleOptions) validateModuleOptions(value, phase)
+  else validateRuntimeOptions(value, phase)
+  return value
+}
+
+function runtimeLayerWithoutActivation(value: JsonObject): JsonObject {
+  const result: JsonObject = {}
+  for (const key of Object.keys(Object.getOwnPropertyDescriptors(value))) {
+    if (key === 'enabled') continue
+    const propertyValue = descriptorValue(value, key)
+    if (propertyValue !== undefined) result[key] = cloneOwnedData(propertyValue)
+  }
+  return result
+}
+
+function resolveModuleActivation(nuxtResolvedOptions: JsonObject): boolean {
+  const enabled = descriptorValue(nuxtResolvedOptions, 'enabled')
+  return enabled === undefined ? PACKAGE_MODULE_DEFAULTS.enabled : enabled as boolean
+}
+
+function resolveExpandOptions(layers: readonly JsonObject[]): JsonObject {
+  let resolved = cloneOwnedData(DEFAULT_EXPAND_OPTIONS) as JsonObject
+
+  for (const layer of layers) {
+    if (!hasOwn(layer, 'expand')) continue
+
+    const expand = descriptorValue(layer, 'expand')
+    if (typeof expand === 'boolean') {
+      resolved = mergeByPresence([DEFAULT_EXPAND_OPTIONS, { enabled: expand }])
+      continue
+    }
+
+    resolved = mergeByPresence([resolved, expand as JsonObject])
+  }
+
+  return resolved
+}
+
+function resolveRuntimeTransport(
+  nuxtResolvedOptions: JsonObject,
+  runtimeOverrides: JsonObject,
+): RuntimeOptions {
+  const runtimeOptions = mergeByPresence([
+    PACKAGE_RUNTIME_DEFAULTS,
+    runtimeLayerWithoutActivation(nuxtResolvedOptions),
+    runtimeOverrides,
+  ])
+  runtimeOptions.expand = resolveExpandOptions([nuxtResolvedOptions, runtimeOverrides])
+
+  validateRuntimeOptions(runtimeOptions, RUNTIME_TRANSPORT_PHASE)
+  return cloneOwnedData(runtimeOptions) as RuntimeOptions
+}
+
+export function resolveModuleConfiguration(
+  input: ModuleConfigurationInput,
+): ResolvedModuleConfiguration {
+  const nuxtResolvedOptions = validateRawLayer(input.nuxtResolvedOptions, NUXT_OPTIONS_PHASE, true)
+  const runtimeOverrides = validateRawLayer(input.runtimeOverrides, RUNTIME_OVERRIDES_PHASE, false)
+
+  return {
+    enabled: resolveModuleActivation(nuxtResolvedOptions),
+    runtimeOptions: resolveRuntimeTransport(nuxtResolvedOptions, runtimeOverrides),
+  }
+}

--- a/src/configuration/module.ts
+++ b/src/configuration/module.ts
@@ -7,13 +7,10 @@ import {
   type ConfigurationValidationPhase,
 } from './core'
 import {
-  DEFAULT_DARK_THEME,
   DEFAULT_EXPAND_OPTIONS,
-  DEFAULT_LIGHT_THEME,
-  DEFAULT_MERMAID_CONFIG,
-  DEFAULT_TOOLBAR_OPTIONS,
+  DEFAULT_RUNTIME_OPTIONS,
 } from '../runtime/constants'
-import type { JsonObject, JsonValue, RuntimeMermaidConfig, RuntimeOptions } from '../types/config'
+import type { JsonObject, JsonValue, RuntimeOptions } from '../types/config'
 
 export interface ModuleConfigurationInput {
   readonly nuxtResolvedOptions: unknown
@@ -25,24 +22,7 @@ export interface ResolvedModuleConfiguration {
   readonly runtimeOptions: RuntimeOptions
 }
 
-const PACKAGE_RUNTIME_DEFAULTS = {
-  loader: {
-    init: DEFAULT_MERMAID_CONFIG as RuntimeMermaidConfig,
-    lazy: true,
-  },
-  theme: {
-    light: DEFAULT_LIGHT_THEME,
-    dark: DEFAULT_DARK_THEME,
-  },
-  components: {},
-  expand: DEFAULT_EXPAND_OPTIONS,
-  toolbar: DEFAULT_TOOLBAR_OPTIONS,
-} satisfies RuntimeOptions
-
-const PACKAGE_MODULE_DEFAULTS = {
-  enabled: true,
-  ...PACKAGE_RUNTIME_DEFAULTS,
-}
+const DEFAULT_MODULE_ACTIVATION = true
 
 const NUXT_OPTIONS_PHASE = {
   name: 'Nuxt-Resolved Module Options',
@@ -270,7 +250,7 @@ function runtimeLayerWithoutActivation(value: JsonObject): JsonObject {
 
 function resolveModuleActivation(nuxtResolvedOptions: JsonObject): boolean {
   const enabled = descriptorValue(nuxtResolvedOptions, 'enabled')
-  return enabled === undefined ? PACKAGE_MODULE_DEFAULTS.enabled : enabled as boolean
+  return enabled === undefined ? DEFAULT_MODULE_ACTIVATION : enabled as boolean
 }
 
 function resolveExpandOptions(layers: readonly JsonObject[]): JsonObject {
@@ -299,7 +279,7 @@ function resolveRuntimeTransport(
   runtimeOverrides: JsonObject,
 ): RuntimeOptions {
   const runtimeOptions = mergeByPresence([
-    PACKAGE_RUNTIME_DEFAULTS,
+    DEFAULT_RUNTIME_OPTIONS,
     runtimeLayerWithoutActivation(nuxtResolvedOptions),
     runtimeOverrides,
   ])

--- a/src/configuration/module.ts
+++ b/src/configuration/module.ts
@@ -85,7 +85,8 @@ function assertPlainObject(
   value: JsonValue,
   phase: ConfigurationValidationPhase,
 ): asserts value is JsonObject {
-  if (value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+  const prototype = value !== null && typeof value === 'object' ? Object.getPrototypeOf(value) : undefined
+  if (value === null || Array.isArray(value) || (prototype !== Object.prototype && prototype !== null)) {
     throwConfigurationIssue(phase, [], 'NON_PLAIN_OBJECT', 'a plain object', 'non-plain-object')
   }
 }
@@ -273,14 +274,17 @@ function resolveModuleActivation(nuxtResolvedOptions: JsonObject): boolean {
 }
 
 function resolveExpandOptions(layers: readonly JsonObject[]): JsonObject {
-  let resolved = cloneOwnedData(DEFAULT_EXPAND_OPTIONS) as JsonObject
+  let resolved = cloneOwnedData(DEFAULT_EXPAND_OPTIONS as unknown as JsonObject)
 
   for (const layer of layers) {
     if (!hasOwn(layer, 'expand')) continue
 
     const expand = descriptorValue(layer, 'expand')
     if (typeof expand === 'boolean') {
-      resolved = mergeByPresence([DEFAULT_EXPAND_OPTIONS, { enabled: expand }])
+      resolved = mergeByPresence([
+        DEFAULT_EXPAND_OPTIONS as unknown as JsonObject,
+        { enabled: expand },
+      ])
       continue
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -168,12 +168,13 @@ export {}
     })
 
     // Transform mermaid fenced code blocks in Markdown
-    nuxt.hook('content:file:beforeParse', (ctx: FileBeforeParseHook) => {
+    // @nuxt/content augments this hook only in consuming applications.
+    nuxt.hook('content:file:beforeParse' as never, ((ctx: FileBeforeParseHook) => {
       const { file } = ctx
 
       if (!file.id?.endsWith('.md')) return
 
       file.body = transformMarkdownDiagrams(file.body)
-    })
+    }) as never)
   },
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -76,6 +76,13 @@ function readRuntimeOverrides(publicRuntimeConfig: object): unknown {
       'accessor',
     )
   }
+  if (!descriptor.enumerable) {
+    throwMigrationError(
+      ['runtimeConfig', 'public', 'contentMermaid'],
+      'an enumerable data property',
+      'non-enumerable-property',
+    )
+  }
   return descriptor.value
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,19 +6,12 @@ import {
   addTypeTemplate,
   addVitePlugin,
   addImports,
-  useLogger,
 } from '@nuxt/kit'
-import { defu } from 'defu'
 import type { FileBeforeParseHook } from '@nuxt/content'
-import {
-  DEFAULT_DARK_THEME,
-  DEFAULT_LIGHT_THEME,
-  DEFAULT_MERMAID_CONFIG,
-  DEFAULT_TOOLBAR_OPTIONS,
-  DEFAULT_EXPAND_OPTIONS,
-} from './runtime/constants'
+import { ContentMermaidConfigurationError } from './configuration/core'
+import { resolveModuleConfiguration } from './configuration/module'
 import { transformMarkdownDiagrams } from './markdown-diagram-transform'
-import type { ModuleOptions, RuntimeMermaidConfig } from './types/config'
+import type { ModuleOptions } from './types/config'
 
 export type {
   MermaidComponentProps,
@@ -53,24 +46,38 @@ const MERMAID_OPTIMIZE_DEPS = [
   'dayjs/plugin/duration.js',
 ]
 
-const DEFAULTS = {
-  enabled: true,
-  loader: {
-    init: { ...DEFAULT_MERMAID_CONFIG } as RuntimeMermaidConfig,
-    lazy: true,
-  },
-  theme: {
-    light: DEFAULT_LIGHT_THEME,
-    dark: DEFAULT_DARK_THEME,
-  },
-  components: {
-    renderer: undefined,
-    spinner: undefined,
-    error: undefined,
-  },
-  expand: DEFAULT_EXPAND_OPTIONS,
-  toolbar: DEFAULT_TOOLBAR_OPTIONS,
-} satisfies ModuleOptions
+const LEGACY_ALIAS_PHASE = {
+  name: 'Nuxt Module Configuration',
+  root: 'nuxt.options',
+} as const
+
+function throwMigrationError(path: readonly string[], expected: string, received: string): never {
+  throw new ContentMermaidConfigurationError(LEGACY_ALIAS_PHASE, [{
+    path,
+    code: 'UNEXPECTED_PROPERTY',
+    expected,
+    received,
+  }], false)
+}
+
+function assertNoLegacyModuleAlias(nuxtOptions: object): void {
+  if (Object.getOwnPropertyDescriptor(nuxtOptions, 'mermaidContent')) {
+    throwMigrationError(['mermaidContent'], 'the supported contentMermaid key', 'removed legacy alias')
+  }
+}
+
+function readRuntimeOverrides(publicRuntimeConfig: object): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(publicRuntimeConfig, 'contentMermaid')
+  if (!descriptor) return undefined
+  if (!('value' in descriptor)) {
+    throwMigrationError(
+      ['runtimeConfig', 'public', 'contentMermaid'],
+      'an enumerable data property',
+      'accessor',
+    )
+  }
+  return descriptor.value
+}
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -80,58 +87,24 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt: '^3.20.1 || ^4.1.0',
     },
   },
-  defaults: {
-    ...DEFAULTS,
-  },
   setup(options, nuxt) {
-    const logger = useLogger('nuxt-content-mermaid')
-    const warn = (message: string) => logger.warn(message)
+    assertNoLegacyModuleAlias(nuxt.options)
+    const publicRuntimeConfig = nuxt.options.runtimeConfig.public
+    const resolved = resolveModuleConfiguration({
+      nuxtResolvedOptions: options,
+      runtimeOverrides: readRuntimeOverrides(publicRuntimeConfig),
+    })
+    if (!resolved.enabled) return
 
-    const deprecatedOptions = (nuxt.options as { mermaidContent?: ModuleOptions }).mermaidContent
-    const hasDeprecatedOptions = deprecatedOptions
-      && typeof deprecatedOptions === 'object'
-      && Object.keys(deprecatedOptions).length > 0
-
-    if (hasDeprecatedOptions)
-      warn('[nuxt-content-mermaid] `mermaidContent` is deprecated, please switch to `contentMermaid`. The old key is still read for now but will be removed in a future release.')
-
-    const resolvedOptions = defu(
-      {},
-      options,
-      deprecatedOptions,
-      DEFAULTS,
-    ) as ModuleOptions
+    publicRuntimeConfig.contentMermaid
+      = resolved.runtimeOptions as typeof publicRuntimeConfig.contentMermaid
 
     const resolver = createResolver(import.meta.url)
     const runtimeDir = resolver.resolve('./runtime')
+    const baseMermaidComponentName = 'Mermaid'
 
     nuxt.options.css ||= []
     nuxt.options.css.push(resolver.resolve('./runtime/styles.css'))
-
-    const publicRuntimeConfig = nuxt.options.runtimeConfig.public
-    const runtimeOverrides = (publicRuntimeConfig.contentMermaid
-      || publicRuntimeConfig.mermaidContent
-      || {}) as Partial<ModuleOptions>
-
-    if (!publicRuntimeConfig.contentMermaid && publicRuntimeConfig.mermaidContent)
-      warn('[nuxt-content-mermaid] `runtimeConfig.public.mermaidContent` is deprecated, please use `runtimeConfig.public.contentMermaid` instead.')
-
-    const runtimeMermaidConfig = defu(
-      {},
-      runtimeOverrides,
-      resolvedOptions,
-    ) as ModuleOptions
-
-    publicRuntimeConfig.contentMermaid
-      = runtimeMermaidConfig as typeof publicRuntimeConfig.contentMermaid
-    publicRuntimeConfig.mermaidContent
-      = runtimeMermaidConfig as typeof publicRuntimeConfig.mermaidContent
-
-    // Transform Markdown output to use fixed <Mermaid>, delegated by runtime components.renderer
-    const baseMermaidComponentName = 'Mermaid'
-
-    const isEnabled = runtimeMermaidConfig.enabled !== false
-    if (!isEnabled) return
 
     // Ensure Vite pre-bundles mermaid and its CJS dependencies so ESM interop works in dev.
     // mermaid's ESM build (`mermaid.core.mjs`) externalizes CJS deps like `dayjs` and

--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -14,7 +14,7 @@ import {
 import { defu } from 'defu'
 import type { Component, ComputedRef } from 'vue'
 import type { MermaidConfig } from 'mermaid'
-import type { ModuleOptions } from '../../module'
+import type { RuntimeOptions } from '../../types/config'
 import { mergeMermaidConfig, resolveMermaidTheme } from '../mermaid-config'
 import { createMermaidRenderer } from '../mermaid-rendering'
 import { parseSizeToPx, isRecord } from '../utils'
@@ -43,16 +43,13 @@ const props = defineProps<{
 
 const nuxtApp = useNuxtApp()
 const runtimeConfig = useRuntimeConfig()
-// Get module options from public runtimeConfig (prefers `contentMermaid`, falls back to deprecated `mermaidContent`)
-const contentMermaidOptions = (runtimeConfig.public?.contentMermaid
-  || runtimeConfig.public?.mermaidContent
-  || {}) as Partial<ModuleOptions>
-const isEnabled = contentMermaidOptions.enabled !== false
+const contentMermaidOptions = (runtimeConfig.public?.contentMermaid || {}) as RuntimeOptions
+const isEnabled = true
 const debug = contentMermaidOptions.debug || false
 const loaderOptions = contentMermaidOptions.loader || {}
 const themeOptions = contentMermaidOptions.theme || {}
 const componentOptions = contentMermaidOptions.components || {}
-function resolveExpandOptions(expand: ModuleOptions['expand']): ExpandOptions {
+function resolveExpandOptions(expand: RuntimeOptions['expand']): ExpandOptions {
   if (expand === false)
     return { ...DEFAULT_EXPAND_OPTIONS, enabled: false }
 

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -1,5 +1,6 @@
 import type { MermaidConfig } from 'mermaid'
 import type { MermaidToolbarOptions } from '../types/mermaid'
+import type { RuntimeMermaidConfig, RuntimeOptions } from '../types/config'
 import type { ExpandOptions } from './types/expand'
 
 export const MERMAID_LOG_PREFIX = '[nuxt-content-mermaid]'
@@ -37,5 +38,19 @@ export const DEFAULT_EXPAND_OPTIONS: ExpandOptions = {
     closeButtonClick: true,
   },
 }
+
+export const DEFAULT_RUNTIME_OPTIONS = {
+  loader: {
+    init: DEFAULT_MERMAID_CONFIG as RuntimeMermaidConfig,
+    lazy: true,
+  },
+  theme: {
+    light: DEFAULT_LIGHT_THEME,
+    dark: DEFAULT_DARK_THEME,
+  },
+  components: {},
+  expand: DEFAULT_EXPAND_OPTIONS,
+  toolbar: DEFAULT_TOOLBAR_OPTIONS,
+} satisfies RuntimeOptions
 
 export const DEFAULT_FRONTMATTER_CONFIG_KEY = 'config'

--- a/src/runtime/plugins/mermaid.client.ts
+++ b/src/runtime/plugins/mermaid.client.ts
@@ -1,6 +1,6 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import type { Mermaid, MermaidConfig } from 'mermaid'
-import type { ModuleOptions } from '../../module'
+import type { RuntimeOptions } from '../../types/config'
 import { DEFAULT_MERMAID_CONFIG } from '../constants'
 
 declare global {
@@ -13,21 +13,7 @@ const globalWithLoader = globalThis as typeof globalThis & {
 
 export default defineNuxtPlugin(() => {
   const runtimeConfig = useRuntimeConfig()
-  const mermaidConfig = (runtimeConfig.public?.contentMermaid
-    ?? runtimeConfig.public?.mermaidContent
-    ?? {}) as ModuleOptions
-
-  if (mermaidConfig?.enabled === false) {
-    return {
-      provide: {
-        mermaid: async () => {
-          throw new Error(
-            '[nuxt-content-mermaid] Mermaid is disabled via config.',
-          )
-        },
-      },
-    }
-  }
+  const mermaidConfig = (runtimeConfig.public?.contentMermaid ?? {}) as RuntimeOptions
 
   const loadMermaid = async (): Promise<Mermaid> => {
     if (globalWithLoader.__nuxtMermaidLoader__)

--- a/test/fixtures/module-configuration-disabled/app.vue
+++ b/test/fixtures/module-configuration-disabled/app.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { useRuntimeConfig } from '#app'
+
+const contentMermaid = useRuntimeConfig().public.contentMermaid
+</script>
+
+<template>
+  <div :data-content-mermaid-present="String(contentMermaid !== undefined)" />
+</template>

--- a/test/fixtures/module-configuration-disabled/nuxt.config.ts
+++ b/test/fixtures/module-configuration-disabled/nuxt.config.ts
@@ -1,0 +1,12 @@
+import contentMermaidModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [contentMermaidModule],
+  compatibilityDate: '2025-11-24',
+  nitro: {
+    compatibilityDate: '2025-11-24',
+  },
+  contentMermaid: {
+    enabled: false,
+  },
+})

--- a/test/fixtures/module-configuration-disabled/package.json
+++ b/test/fixtures/module-configuration-disabled/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "module-configuration-disabled",
+  "type": "module"
+}

--- a/test/fixtures/module-configuration-legacy/nuxt.config.ts
+++ b/test/fixtures/module-configuration-legacy/nuxt.config.ts
@@ -1,0 +1,11 @@
+import contentMermaidModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [contentMermaidModule],
+  compatibilityDate: '2025-11-24',
+  nitro: {
+    compatibilityDate: '2025-11-24',
+  },
+  // @ts-expect-error 3.0 removes the legacy configuration key
+  mermaidContent: {},
+})

--- a/test/fixtures/module-configuration-legacy/package.json
+++ b/test/fixtures/module-configuration-legacy/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "module-configuration-legacy",
+  "type": "module"
+}

--- a/test/fixtures/module-configuration/app.vue
+++ b/test/fixtures/module-configuration/app.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { useRuntimeConfig } from '#app'
+
+const contentMermaid = useRuntimeConfig().public.contentMermaid ?? {}
+
+const hasModuleActivation = Object.prototype.hasOwnProperty.call(contentMermaid, 'enabled')
+const expand = contentMermaid.expand
+const expandEnabled = expand === false
+  ? false
+  : typeof expand === 'object' && expand !== null
+    ? expand.enabled
+    : undefined
+</script>
+
+<template>
+  <pre
+    :data-has-module-activation="String(hasModuleActivation)"
+    :data-expand-enabled="String(expandEnabled)"
+  >{{ JSON.stringify(contentMermaid) }}</pre>
+</template>

--- a/test/fixtures/module-configuration/nuxt.config.ts
+++ b/test/fixtures/module-configuration/nuxt.config.ts
@@ -1,0 +1,45 @@
+import contentMermaidModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [contentMermaidModule],
+  runtimeConfig: {
+    public: {
+      contentMermaid: {
+        debug: false,
+        expand: {
+          margin: 24,
+        },
+        toolbar: {
+          title: 'runtime-title',
+          buttons: {
+            fullscreen: false,
+          },
+        },
+        loader: {
+          init: {
+            unknownMermaidExtension: 'runtime-mermaid-extension',
+          },
+        },
+      },
+    },
+  },
+  compatibilityDate: '2025-11-24',
+  nitro: {
+    compatibilityDate: '2025-11-24',
+  },
+  contentMermaid: {
+    debug: true,
+    expand: false,
+    toolbar: {
+      title: 'Nuxt option title',
+      buttons: {
+        copy: false,
+      },
+    },
+    loader: {
+      init: {
+        theme: 'forest',
+      },
+    },
+  },
+})

--- a/test/fixtures/module-configuration/package.json
+++ b/test/fixtures/module-configuration/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "module-configuration",
+  "type": "module"
+}

--- a/test/moduleConfiguration.e2e.test.ts
+++ b/test/moduleConfiguration.e2e.test.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+
+describe('module configuration fixture', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/module-configuration', import.meta.url)),
+  })
+
+  it('publishes the canonical runtime transport after applying fixed precedence', async () => {
+    const html = await $fetch('/')
+
+    expect(html).toContain('runtime-title')
+    expect(html).toContain('runtime-mermaid-extension')
+    expect(html).toContain('data-has-module-activation="false"')
+    expect(html).toContain('data-expand-enabled="false"')
+  })
+})

--- a/test/moduleConfiguration.test.ts
+++ b/test/moduleConfiguration.test.ts
@@ -82,4 +82,52 @@ describe('module configuration resolver', () => {
     result.runtimeOptions.toolbar!.title = 'package-owned result'
     expect(overrides.toolbar.title).toBe('application input')
   })
+
+  it('replaces Mermaid-owned arrays and falsy values without backfilling null or zero', () => {
+    const result = resolveModuleConfiguration({
+      nuxtResolvedOptions: {
+        loader: {
+          init: {
+            unknownMermaidExtension: {
+              values: ['Nuxt option'],
+              nullable: 'Nuxt option',
+              count: 1,
+              enabled: true,
+            },
+          },
+        },
+      },
+      runtimeOverrides: {
+        loader: {
+          init: {
+            unknownMermaidExtension: {
+              values: [],
+              nullable: null,
+              count: 0,
+              enabled: false,
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.runtimeOptions.loader?.init).toMatchObject({
+      unknownMermaidExtension: {
+        values: [],
+        nullable: null,
+        count: 0,
+        enabled: false,
+      },
+    })
+  })
+
+  it('rejects a non-boolean activation value', () => {
+    expect(() => resolveModuleConfiguration({
+      nuxtResolvedOptions: { enabled: 'false' },
+      runtimeOverrides: {},
+    })).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+  })
 })

--- a/test/moduleConfiguration.test.ts
+++ b/test/moduleConfiguration.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { resolveModuleConfiguration } from '../src/configuration/module'
+
+describe('module configuration resolver', () => {
+  it('merges package defaults, Nuxt options, and runtime overrides in order without transporting activation', () => {
+    const result = resolveModuleConfiguration({
+      nuxtResolvedOptions: {
+        enabled: false,
+        debug: true,
+        toolbar: { title: 'Nuxt option', buttons: { copy: false } },
+        loader: { init: { theme: 'forest' } },
+        expand: false,
+      },
+      runtimeOverrides: {
+        debug: false,
+        toolbar: { title: '', buttons: { fullscreen: false } },
+        loader: { init: { unknownMermaidExtension: { values: [] } } },
+        expand: { margin: 24 },
+      },
+    })
+
+    expect(result.enabled).toBe(false)
+    expect(result.runtimeOptions).toMatchObject({
+      debug: false,
+      toolbar: {
+        title: '',
+        buttons: { copy: false, fullscreen: false, expand: true },
+      },
+      loader: {
+        init: {
+          theme: 'forest',
+          unknownMermaidExtension: { values: [] },
+        },
+      },
+      expand: { enabled: false, margin: 24 },
+    })
+    expect(result.runtimeOptions).not.toHaveProperty('enabled')
+  })
+
+  it('rejects activation in runtime overrides even when the module is disabled', () => {
+    expect(() => resolveModuleConfiguration({
+      nuxtResolvedOptions: { enabled: false },
+      runtimeOverrides: { enabled: false },
+    })).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+  })
+
+  it('validates application-owned descriptors without invoking getters', () => {
+    let getterCalls = 0
+    const runtimeOverrides = {}
+    Object.defineProperty(runtimeOverrides, 'debug', {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        return true
+      },
+    })
+
+    expect(() => resolveModuleConfiguration({
+      nuxtResolvedOptions: {},
+      runtimeOverrides,
+    })).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+    expect(getterCalls).toBe(0)
+  })
+
+  it('returns a mutable owned runtime payload', () => {
+    const overrides = { toolbar: { title: 'application input' } }
+    const result = resolveModuleConfiguration({
+      nuxtResolvedOptions: {},
+      runtimeOverrides: overrides,
+    })
+
+    expect(result.runtimeOptions).not.toBe(overrides)
+    expect(result.runtimeOptions.toolbar).not.toBe(overrides.toolbar)
+    expect(Object.isFrozen(result.runtimeOptions)).toBe(false)
+
+    result.runtimeOptions.toolbar!.title = 'package-owned result'
+    expect(overrides.toolbar.title).toBe('application input')
+  })
+})

--- a/test/moduleConfigurationMigration.e2e.test.ts
+++ b/test/moduleConfigurationMigration.e2e.test.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, createTestContext, loadFixture, setup } from '@nuxt/test-utils/e2e'
+
+describe('disabled module configuration fixture', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/module-configuration-disabled', import.meta.url)),
+  })
+
+  it('does not publish runtime transport when activation is disabled', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('data-content-mermaid-present="false"')
+  })
+})
+
+describe('legacy module configuration fixture', () => {
+  it('fails with the public migration fingerprint', async () => {
+    createTestContext({
+      rootDir: fileURLToPath(new URL('./fixtures/module-configuration-legacy', import.meta.url)),
+      browser: false,
+      build: true,
+      server: false,
+    })
+
+    await expect(loadFixture()).rejects.toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+  })
+})

--- a/test/moduleSetup.test.ts
+++ b/test/moduleSetup.test.ts
@@ -154,6 +154,25 @@ describe('module setup', () => {
     expect(Object.keys(hooks)).toHaveLength(0)
   })
 
+  it('rejects a non-enumerable canonical runtime override before integration is installed', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt, hooks } = createNuxtStub()
+
+    Object.defineProperty(nuxt.options.runtimeConfig.public, 'contentMermaid', {
+      enumerable: false,
+      value: { debug: true },
+    })
+
+    expect(() => moduleDef.setup?.({}, nuxt)).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+    expect(nuxt.options.css).toBeUndefined()
+    expect(addPlugin).not.toHaveBeenCalled()
+    expect(Object.keys(hooks)).toHaveLength(0)
+  })
+
   it('registers module hooks', async () => {
     const mod = await import('../src/module')
     const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }

--- a/test/moduleSetup.test.ts
+++ b/test/moduleSetup.test.ts
@@ -30,7 +30,11 @@ vi.mock('../src/markdown-diagram-transform', () => ({
 }))
 
 interface NuxtStub {
-  options: { runtimeConfig: { public: Record<string, unknown> } }
+  options: {
+    css?: string[]
+    mermaidContent?: unknown
+    runtimeConfig: { public: Record<string, unknown> }
+  }
   hook: (name: string, fn: (...args: unknown[]) => void) => void
 }
 
@@ -73,12 +77,80 @@ describe('module setup', () => {
     const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
     const { nuxt, hooks } = createNuxtStub()
 
+    const publicRuntimeConfig = nuxt.options.runtimeConfig.public
+
     await moduleDef.setup?.({ enabled: false }, nuxt)
 
     expect(addPlugin).not.toHaveBeenCalled()
     expect(addComponent).not.toHaveBeenCalled()
     expect(addTypeTemplate).not.toHaveBeenCalled()
     expect(addVitePlugin).not.toHaveBeenCalled()
+    expect(addImports).not.toHaveBeenCalled()
+    expect(nuxt.options.css).toBeUndefined()
+    expect(nuxt.options.runtimeConfig.public).toBe(publicRuntimeConfig)
+    expect(publicRuntimeConfig).toEqual({})
+    expect(Object.keys(hooks)).toHaveLength(0)
+  })
+
+  it('fails for an own legacy alias without invoking its getter or installing integration', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt, hooks } = createNuxtStub()
+    let getterCalls = 0
+
+    Object.defineProperty(nuxt.options, 'mermaidContent', {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        return undefined
+      },
+    })
+
+    expect(() => moduleDef.setup?.({}, nuxt)).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+    expect(getterCalls).toBe(0)
+    expect(nuxt.options.css).toBeUndefined()
+    expect(nuxt.options.runtimeConfig.public).toEqual({})
+    expect(addPlugin).not.toHaveBeenCalled()
+    expect(addComponent).not.toHaveBeenCalled()
+    expect(addTypeTemplate).not.toHaveBeenCalled()
+    expect(addVitePlugin).not.toHaveBeenCalled()
+    expect(addImports).not.toHaveBeenCalled()
+    expect(Object.keys(hooks)).toHaveLength(0)
+  })
+
+  it('fails for an own legacy alias whose data value is undefined', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt } = createNuxtStub()
+
+    Object.defineProperty(nuxt.options, 'mermaidContent', {
+      enumerable: true,
+      value: undefined,
+    })
+
+    expect(() => moduleDef.setup?.({}, nuxt)).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+    expect(addPlugin).not.toHaveBeenCalled()
+    expect(nuxt.options.runtimeConfig.public).toEqual({})
+  })
+
+  it('validates runtime activation before disabled setup returns', async () => {
+    const mod = await import('../src/module')
+    const moduleDef = mod.default as { setup?: (options: Partial<ModuleOptions>, nuxt: NuxtStub) => unknown }
+    const { nuxt, hooks } = createNuxtStub()
+    nuxt.options.runtimeConfig.public.contentMermaid = { enabled: false }
+
+    expect(() => moduleDef.setup?.({ enabled: false }, nuxt)).toThrowError(expect.objectContaining({
+      name: 'ContentMermaidConfigurationError',
+      code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+    }))
+    expect(nuxt.options.css).toBeUndefined()
+    expect(addPlugin).not.toHaveBeenCalled()
     expect(Object.keys(hooks)).toHaveLength(0)
   })
 
@@ -94,6 +166,9 @@ describe('module setup', () => {
     expect(addTypeTemplate).toHaveBeenCalled()
     expect(addVitePlugin).toHaveBeenCalledTimes(1)
     expect(hooks['content:file:beforeParse']).toHaveLength(1)
+    expect(nuxt.options.runtimeConfig.public).toHaveProperty('contentMermaid')
+    expect(nuxt.options.runtimeConfig.public.contentMermaid).not.toHaveProperty('enabled')
+    expect(nuxt.options.runtimeConfig.public).not.toHaveProperty('mermaidContent')
 
     const createOptimizeDepsPlugin = addVitePlugin.mock.calls[0]?.[0] as
       (() => { configEnvironment?: (name: string, config: Record<string, unknown>) => void })


### PR DESCRIPTION
## 摘要
- 新增純函式且 descriptor-safe 的 module configuration resolver，分離 activation 與 runtime transport。
- 只在完整解析且啟用後，原子寫入唯一的 `runtimeConfig.public.contentMermaid`，並安裝 Nuxt 整合。
- 移除 module defaults、legacy runtime fallback；補足 enabled、disabled、legacy migration、priority 與 descriptor 安全測試。
- 將 Nuxt 3.20.1／4.1.0 fixture 驗證納入 CI。

## 驗證
- `pnpm lint`
- `pnpm test`
- `pnpm test:types`
- `pnpm test:package-contract`
- `pnpm dev:build`
- 已於暫存 clone 以 Nuxt 3.20.1、4.1.0 各執行 module configuration e2e 測試。

Closes #25