### PR TITLE
feat: snapshot runtime options per Nuxt app

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ A zoom toolbar appears with +/−/Reset buttons and a percentage display.
 Use `toolbar.fullscreenToolbarScale` to scale the fullscreen toolbar and zoom controls.
 
 
-> **Note**: All options can be overridden at runtime via `runtimeConfig.public.contentMermaid` (`runtimeConfig.public.mermaidContent` remains supported but deprecated).
+> **Note**: `runtimeConfig.public.contentMermaid` is resolved once during each Nuxt application initialization. Mutating it afterward does not update the established runtime snapshot. The legacy `runtimeConfig.public.mermaidContent` key is not supported in v3.
 
 ## Styling (CSS Variables)
 

--- a/src/configuration/module.ts
+++ b/src/configuration/module.ts
@@ -9,8 +9,11 @@ import {
 import {
   DEFAULT_EXPAND_OPTIONS,
   DEFAULT_RUNTIME_OPTIONS,
+  DEFAULT_TOOLBAR_OPTIONS,
 } from '../runtime/constants'
 import type { JsonObject, JsonValue, RuntimeOptions } from '../types/config'
+import type { MermaidToolbarOptions } from '../types/mermaid'
+import type { ExpandOptions } from '../runtime/types/expand'
 
 export interface ModuleConfigurationInput {
   readonly nuxtResolvedOptions: unknown
@@ -144,7 +147,7 @@ function assertObjectProperty(
   return nested
 }
 
-function validateRuntimeOptions(value: JsonObject, phase: ConfigurationValidationPhase): void {
+export function validateRuntimeOptions(value: JsonObject, phase: ConfigurationValidationPhase): void {
   assertKnownKeys(value, RUNTIME_OPTION_KEYS, phase)
   assertBooleanProperty(value, 'debug', phase, [])
 
@@ -153,6 +156,12 @@ function validateRuntimeOptions(value: JsonObject, phase: ConfigurationValidatio
     const init = assertObjectProperty(loader, 'init', phase, ['loader'])
     if (init) {
       assertStringProperty(init, 'theme', phase, ['loader', 'init'])
+      if (hasOwn(init, 'logLevel')) {
+        const logLevel = descriptorValue(init, 'logLevel')
+        if (typeof logLevel !== 'string' && typeof logLevel !== 'number') {
+          throwConfigurationIssue(phase, ['loader', 'init', 'logLevel'], 'INVALID_VALUE', 'a string or number', typeof logLevel)
+        }
+      }
       assertBooleanProperty(init, 'suppressErrorRendering', phase, ['loader', 'init'])
     }
 
@@ -238,6 +247,13 @@ function validateRawLayer(value: unknown, phase: ConfigurationValidationPhase, m
   return value
 }
 
+export function validateRuntimeOptionsInput(
+  value: unknown,
+  phase: ConfigurationValidationPhase,
+): JsonObject {
+  return validateRawLayer(value, phase, false)
+}
+
 function runtimeLayerWithoutActivation(value: JsonObject): JsonObject {
   const result: JsonObject = {}
   for (const key of Object.keys(Object.getOwnPropertyDescriptors(value))) {
@@ -253,13 +269,13 @@ function resolveModuleActivation(nuxtResolvedOptions: JsonObject): boolean {
   return enabled === undefined ? DEFAULT_MODULE_ACTIVATION : enabled as boolean
 }
 
-function resolveExpandOptions(layers: readonly JsonObject[]): JsonObject {
+export function resolveExpandOptions(
+  layers: readonly (RuntimeOptions['expand'] | undefined)[],
+): ExpandOptions {
   let resolved = cloneOwnedData(DEFAULT_EXPAND_OPTIONS as unknown as JsonObject)
 
-  for (const layer of layers) {
-    if (!hasOwn(layer, 'expand')) continue
-
-    const expand = descriptorValue(layer, 'expand')
+  for (const expand of layers) {
+    if (expand === undefined) continue
     if (typeof expand === 'boolean') {
       resolved = mergeByPresence([
         DEFAULT_EXPAND_OPTIONS as unknown as JsonObject,
@@ -271,7 +287,16 @@ function resolveExpandOptions(layers: readonly JsonObject[]): JsonObject {
     resolved = mergeByPresence([resolved, expand as JsonObject])
   }
 
-  return resolved
+  return cloneOwnedData(resolved) as unknown as ExpandOptions
+}
+
+export function resolveToolbarOptions(
+  layers: readonly (RuntimeOptions['toolbar'] | undefined)[],
+): MermaidToolbarOptions {
+  return mergeByPresence([
+    DEFAULT_TOOLBAR_OPTIONS as unknown as JsonObject,
+    ...layers.filter((layer): layer is MermaidToolbarOptions => layer !== undefined),
+  ]) as unknown as MermaidToolbarOptions
 }
 
 function resolveRuntimeTransport(
@@ -283,7 +308,22 @@ function resolveRuntimeTransport(
     runtimeLayerWithoutActivation(nuxtResolvedOptions),
     runtimeOverrides,
   ])
-  runtimeOptions.expand = resolveExpandOptions([nuxtResolvedOptions, runtimeOverrides])
+  runtimeOptions.expand = resolveExpandOptions([
+    hasOwn(nuxtResolvedOptions, 'expand')
+      ? descriptorValue(nuxtResolvedOptions, 'expand') as RuntimeOptions['expand']
+      : undefined,
+    hasOwn(runtimeOverrides, 'expand')
+      ? descriptorValue(runtimeOverrides, 'expand') as RuntimeOptions['expand']
+      : undefined,
+  ]) as unknown as JsonValue
+  runtimeOptions.toolbar = resolveToolbarOptions([
+    hasOwn(nuxtResolvedOptions, 'toolbar')
+      ? descriptorValue(nuxtResolvedOptions, 'toolbar') as RuntimeOptions['toolbar']
+      : undefined,
+    hasOwn(runtimeOverrides, 'toolbar')
+      ? descriptorValue(runtimeOverrides, 'toolbar') as RuntimeOptions['toolbar']
+      : undefined,
+  ]) as unknown as JsonValue
 
   validateRuntimeOptions(runtimeOptions, RUNTIME_TRANSPORT_PHASE)
   return cloneOwnedData(runtimeOptions) as RuntimeOptions

--- a/src/module.ts
+++ b/src/module.ts
@@ -133,10 +133,14 @@ export default defineNuxtModule<ModuleOptions>({
       },
     }))
 
-    // Inject client plugin
+    // Nuxt Kit prepends plugins, so register the loader first to place the
+    // Universal Runtime Adapter ahead of it in the final plugin array.
     addPlugin({
       src: resolver.resolve(runtimeDir, 'plugins/mermaid.client'),
       mode: 'client',
+    })
+    addPlugin({
+      src: resolver.resolve(runtimeDir, 'plugins/runtime-config'),
     })
 
     // Register built-in Mermaid wrapper, can be overridden at runtime

--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -207,13 +207,13 @@ const mermaidTheme = computed(() => {
   })
 })
 
-const effectiveMermaidInit = computed<MermaidConfig>(() => {
+function materializeEffectiveMermaidInit(): MermaidConfig {
   return mergeMermaidConfig({
     baseConfig: baseMermaidInit,
     overrideConfig: pageConfig.value,
     theme: mermaidTheme.value,
   })
-})
+}
 
 const configuredSpinnerName = computed(() => componentOptions.spinner?.trim() || '')
 const customSpinner = shallowRef<Component | null>(null)
@@ -252,7 +252,7 @@ function getBuiltInRenderRequest() {
     loadMermaid: $mermaid,
     readRenderData: () => ({
       source: mermaidDefinition.value,
-      config: effectiveMermaidInit.value,
+      config: materializeEffectiveMermaidInit(),
       target: mermaidContainer.value,
     }),
     beforeCommit: () => {

--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useNuxtApp, useRuntimeConfig } from '#app'
+import { useNuxtApp } from '#app'
 import {
   ref,
   onMounted,
@@ -14,13 +14,12 @@ import {
 import { defu } from 'defu'
 import type { Component, ComputedRef } from 'vue'
 import type { MermaidConfig } from 'mermaid'
-import type { RuntimeOptions } from '../../types/config'
 import { mergeMermaidConfig, resolveMermaidTheme } from '../mermaid-config'
 import { createMermaidRenderer } from '../mermaid-rendering'
+import { getRuntimeMermaidSnapshot } from '../runtime-snapshot'
 import { parseSizeToPx, isRecord } from '../utils'
 import { useMermaidTheme } from '../composables/useMermaidTheme'
 import { useMermaidCursors } from '../composables/useMermaidCursors'
-import { DEFAULT_TOOLBAR_OPTIONS, DEFAULT_EXPAND_OPTIONS } from '../constants'
 import type { ExpandOptions } from '../types/expand'
 import Spinner from './Spinner.vue'
 import IconClipboard from './icons/IconClipboard.vue'
@@ -42,25 +41,15 @@ const props = defineProps<{
 }>()
 
 const nuxtApp = useNuxtApp()
-const runtimeConfig = useRuntimeConfig()
-const contentMermaidOptions = (runtimeConfig.public?.contentMermaid || {}) as RuntimeOptions
+const contentMermaidOptions = getRuntimeMermaidSnapshot(nuxtApp)
 const isEnabled = true
 const debug = contentMermaidOptions.debug || false
 const loaderOptions = contentMermaidOptions.loader || {}
 const themeOptions = contentMermaidOptions.theme || {}
 const componentOptions = contentMermaidOptions.components || {}
-function resolveExpandOptions(expand: RuntimeOptions['expand']): ExpandOptions {
-  if (expand === false)
-    return { ...DEFAULT_EXPAND_OPTIONS, enabled: false }
-
-  if (expand === true || !expand || typeof expand !== 'object')
-    return DEFAULT_EXPAND_OPTIONS
-
-  return defu({}, expand as ExpandOptions, DEFAULT_EXPAND_OPTIONS)
-}
 
 // Expand options and flags
-const expandOptions = resolveExpandOptions(contentMermaidOptions.expand)
+const expandOptions = contentMermaidOptions.expand as unknown as ExpandOptions
 const expandEnabled = expandOptions.enabled !== false
 const expandOpenOptions = expandOptions.invokeOpenOn || {}
 const allowOpenDiagramClick = expandOpenOptions.diagramClick !== false
@@ -109,17 +98,13 @@ const decodedCode = computed(() => props.code ? decodeURIComponent(props.code) :
 const mermaidDefinition = ref(decodedCode.value)
 let observer: IntersectionObserver | null = null
 
-const defaultToolbarTitle = DEFAULT_TOOLBAR_OPTIONS.title ?? 'mermaid'
-const defaultToolbarFontSize = DEFAULT_TOOLBAR_OPTIONS.fontSize ?? '14px'
-const defaultFullscreenToolbarScale = DEFAULT_TOOLBAR_OPTIONS.fullscreenToolbarScale ?? 1.25
+const runtimeToolbarDefaults = contentMermaidOptions.toolbar
+const defaultToolbarTitle = runtimeToolbarDefaults?.title ?? 'mermaid'
+const defaultToolbarFontSize = runtimeToolbarDefaults?.fontSize ?? '14px'
+const defaultFullscreenToolbarScale = runtimeToolbarDefaults?.fullscreenToolbarScale ?? 1.25
 
-const baseToolbarDefaults: MermaidToolbarOptions = DEFAULT_TOOLBAR_OPTIONS
-const runtimeToolbarDefaults = computed<MermaidToolbarOptions>(() => {
-  const toolbar = contentMermaidOptions.toolbar
-  return toolbar && typeof toolbar === 'object' ? toolbar : {}
-})
 const resolvedToolbar = computed<MermaidToolbarOptions>(() => {
-  return defu({}, props.toolbar ?? {}, runtimeToolbarDefaults.value, baseToolbarDefaults)
+  return defu({}, props.toolbar ?? {}, runtimeToolbarDefaults ?? {})
 })
 
 const toolbarButtons = computed<NonNullable<MermaidToolbarOptions['buttons']>>(() => {

--- a/src/runtime/configuration/runtime-options.ts
+++ b/src/runtime/configuration/runtime-options.ts
@@ -1,0 +1,83 @@
+import {
+  cloneAndDeepFreezeOwnedData,
+  mergeByPresence,
+  type DeepReadonlyData,
+  type ConfigurationValidationPhase,
+} from '../../configuration/core'
+import {
+  resolveExpandOptions,
+  resolveToolbarOptions,
+  validateRuntimeOptions,
+  validateRuntimeOptionsInput,
+} from '../../configuration/module'
+import type { JsonObject, JsonValue, RuntimeOptions } from '../../types/config'
+import { DEFAULT_RUNTIME_OPTIONS } from '../constants'
+
+const RUNTIME_PAYLOAD_PHASE = {
+  name: 'Runtime Mermaid Options',
+  root: 'runtimeConfig.public.contentMermaid',
+} as const
+
+const RUNTIME_SNAPSHOT_PHASE = {
+  name: 'Runtime Mermaid Snapshot',
+  root: 'runtimeConfig.public.contentMermaid',
+} as const
+
+export type ResolvedRuntimeOptions = DeepReadonlyData<RuntimeOptions>
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function descriptorValue(value: JsonObject, key: string): JsonValue | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key)
+  return descriptor && 'value' in descriptor ? descriptor.value as JsonValue : undefined
+}
+
+function resolveDebugDefaults(runtimeOptions: JsonObject, rawOptions: JsonObject): void {
+  const debug = descriptorValue(runtimeOptions, 'debug') === true
+  const loader = descriptorValue(runtimeOptions, 'loader') as JsonObject
+  const init = descriptorValue(loader, 'init') as JsonObject
+  const rawLoader = descriptorValue(rawOptions, 'loader')
+  const rawInit = rawLoader && typeof rawLoader === 'object' && !Array.isArray(rawLoader)
+    ? descriptorValue(rawLoader, 'init')
+    : undefined
+  const explicitInit = rawInit && typeof rawInit === 'object' && !Array.isArray(rawInit)
+    ? rawInit
+    : undefined
+
+  if (!explicitInit || !hasOwn(explicitInit, 'logLevel')) init.logLevel = debug ? 1 : 5
+  if (!explicitInit || !hasOwn(explicitInit, 'suppressErrorRendering')) {
+    init.suppressErrorRendering = !debug
+  }
+}
+
+function resolveRuntimeOptions(
+  rawOptions: JsonObject,
+  finalPhase: ConfigurationValidationPhase,
+): ResolvedRuntimeOptions {
+  const runtimeOptions = mergeByPresence([
+    DEFAULT_RUNTIME_OPTIONS,
+    rawOptions,
+  ])
+
+  runtimeOptions.expand = resolveExpandOptions([
+    hasOwn(rawOptions, 'expand')
+      ? descriptorValue(rawOptions, 'expand') as RuntimeOptions['expand']
+      : undefined,
+  ]) as unknown as JsonValue
+  runtimeOptions.toolbar = resolveToolbarOptions([
+    hasOwn(rawOptions, 'toolbar')
+      ? descriptorValue(rawOptions, 'toolbar') as RuntimeOptions['toolbar']
+      : undefined,
+  ]) as unknown as JsonValue
+  resolveDebugDefaults(runtimeOptions, rawOptions)
+  validateRuntimeOptions(runtimeOptions, finalPhase)
+
+  return cloneAndDeepFreezeOwnedData(runtimeOptions) as ResolvedRuntimeOptions
+}
+
+export function resolveRuntimeOptionsSnapshot(payload: unknown): ResolvedRuntimeOptions {
+  const rawOptions = validateRuntimeOptionsInput(payload, RUNTIME_PAYLOAD_PHASE)
+  return resolveRuntimeOptions(rawOptions, RUNTIME_SNAPSHOT_PHASE)
+}

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -40,6 +40,7 @@ export const DEFAULT_EXPAND_OPTIONS: ExpandOptions = {
 }
 
 export const DEFAULT_RUNTIME_OPTIONS = {
+  debug: false,
   loader: {
     init: DEFAULT_MERMAID_CONFIG as RuntimeMermaidConfig,
     lazy: true,

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -12,7 +12,6 @@ export const DEFAULT_MERMAID_CONFIG: MermaidConfig = {
   theme: 'default',
   fontFamily: 'Arial, sans-serif, 微軟正黑體',
   securityLevel: 'strict',
-  logLevel: 'error',
 }
 export const DEFAULT_TOOLBAR_OPTIONS: MermaidToolbarOptions = {
   title: 'mermaid',

--- a/src/runtime/mermaid-config.ts
+++ b/src/runtime/mermaid-config.ts
@@ -51,6 +51,51 @@ interface MergeOptions extends MermaidConfig {
   theme?: MermaidConfig['theme']
 }
 
+function materializeStructuralData(
+  value: unknown,
+  memo: WeakMap<object, unknown>,
+): unknown {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function'))
+    return value
+  if (typeof value === 'function')
+    return value
+
+  const existing = memo.get(value)
+  if (existing !== undefined)
+    return existing
+
+  if (Array.isArray(value)) {
+    const clone: unknown[] = []
+    memo.set(value, clone)
+    for (const item of value)
+      clone.push(materializeStructuralData(item, memo))
+    return clone
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null)
+    return value
+
+  const clone = Object.create(prototype) as Record<PropertyKey, unknown>
+  memo.set(value, clone)
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !('value' in descriptor))
+      continue
+    Object.defineProperty(clone, key, {
+      configurable: true,
+      enumerable: true,
+      value: materializeStructuralData(descriptor.value, memo),
+      writable: true,
+    })
+  }
+  return clone
+}
+
+function materializeMermaidConfigWorkingCopy(config: MermaidConfig): MermaidConfig {
+  return materializeStructuralData(config, new WeakMap()) as MermaidConfig
+}
+
 export function mergeMermaidConfig(options: MergeOptions): MermaidConfig {
   const {
     baseConfig,
@@ -66,9 +111,9 @@ export function mergeMermaidConfig(options: MergeOptions): MermaidConfig {
     baseConfig || {},
   ) as MermaidConfig
 
-  return {
+  return materializeMermaidConfigWorkingCopy({
     startOnLoad: false,
     ...merged,
     theme: theme ?? merged.theme,
-  }
+  })
 }

--- a/src/runtime/plugins/mermaid.client.ts
+++ b/src/runtime/plugins/mermaid.client.ts
@@ -1,55 +1,33 @@
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin } from '#app'
 import type { Mermaid, MermaidConfig } from 'mermaid'
-import type { RuntimeOptions } from '../../types/config'
-import { DEFAULT_MERMAID_CONFIG } from '../constants'
+import { cloneOwnedData } from '../../configuration/core'
+import type { JsonObject } from '../../types/config'
+import { getRuntimeMermaidSnapshot } from '../runtime-snapshot'
 
-declare global {
-  var __nuxtMermaidLoader__: Promise<Mermaid> | undefined
-}
-
-const globalWithLoader = globalThis as typeof globalThis & {
-  __nuxtMermaidLoader__?: Promise<Mermaid>
-}
-
-export default defineNuxtPlugin(() => {
-  const runtimeConfig = useRuntimeConfig()
-  const mermaidConfig = (runtimeConfig.public?.contentMermaid ?? {}) as RuntimeOptions
+export default defineNuxtPlugin((nuxtApp) => {
+  const snapshot = getRuntimeMermaidSnapshot(nuxtApp)
+  let mermaidLoader: Promise<Mermaid> | undefined
 
   const loadMermaid = async (): Promise<Mermaid> => {
-    if (globalWithLoader.__nuxtMermaidLoader__)
-      return globalWithLoader.__nuxtMermaidLoader__
+    if (mermaidLoader) return mermaidLoader
 
-    const debug = mermaidConfig?.debug || false
-    const userInit = mermaidConfig?.loader?.init || {}
-    const hasUserLogLevel = Object.prototype.hasOwnProperty.call(userInit, 'logLevel')
-    const hasUserSuppressErrorRendering
-      = Object.prototype.hasOwnProperty.call(userInit, 'suppressErrorRendering')
-
-    const initOptions: MermaidConfig = {
-      ...DEFAULT_MERMAID_CONFIG,
-      ...userInit,
-      logLevel: hasUserLogLevel ? userInit.logLevel : (debug ? 1 : 5),
-      suppressErrorRendering: hasUserSuppressErrorRendering
-        ? userInit.suppressErrorRendering
-        : !debug,
-    }
-
-    // await new Promise(resolve => setTimeout(resolve, 2000))
-
-    globalWithLoader.__nuxtMermaidLoader__ = (async () => {
+    mermaidLoader = (async () => {
       try {
         const mermaid = await import('mermaid')
         const mermaidInstance = (mermaid.default ?? mermaid) as Mermaid
+        const initOptions = cloneOwnedData(
+          (snapshot.loader?.init ?? {}) as unknown as JsonObject,
+        ) as MermaidConfig
         mermaidInstance.initialize(initOptions)
         return mermaidInstance
       }
       catch (error) {
-        globalWithLoader.__nuxtMermaidLoader__ = undefined
+        mermaidLoader = undefined
         throw error
       }
     })()
 
-    return globalWithLoader.__nuxtMermaidLoader__
+    return mermaidLoader
   }
 
   return {

--- a/src/runtime/plugins/runtime-config.ts
+++ b/src/runtime/plugins/runtime-config.ts
@@ -1,0 +1,10 @@
+import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { installRuntimeMermaidSnapshot } from '../runtime-snapshot'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const runtimeConfig = useRuntimeConfig()
+  installRuntimeMermaidSnapshot(
+    nuxtApp,
+    runtimeConfig.public?.contentMermaid ?? {},
+  )
+})

--- a/src/runtime/plugins/runtime-config.ts
+++ b/src/runtime/plugins/runtime-config.ts
@@ -5,6 +5,6 @@ export default defineNuxtPlugin((nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   installRuntimeMermaidSnapshot(
     nuxtApp,
-    runtimeConfig.public?.contentMermaid ?? {},
+    runtimeConfig.public?.contentMermaid,
   )
 })

--- a/src/runtime/runtime-snapshot.ts
+++ b/src/runtime/runtime-snapshot.ts
@@ -1,0 +1,38 @@
+import {
+  resolveRuntimeOptionsSnapshot,
+  type ResolvedRuntimeOptions,
+} from './configuration/runtime-options'
+
+const runtimeMermaidSnapshotKey: unique symbol = Symbol('nuxt-content-mermaid:runtime-snapshot')
+
+type RuntimeSnapshotApp = object & {
+  readonly [runtimeMermaidSnapshotKey]?: ResolvedRuntimeOptions
+}
+
+export function installRuntimeMermaidSnapshot(
+  nuxtApp: object,
+  payload: unknown,
+): ResolvedRuntimeOptions {
+  const app = nuxtApp as RuntimeSnapshotApp
+  const installed = app[runtimeMermaidSnapshotKey]
+  if (installed) return installed
+
+  const snapshot = resolveRuntimeOptionsSnapshot(payload)
+  Object.defineProperty(app, runtimeMermaidSnapshotKey, {
+    configurable: false,
+    enumerable: false,
+    value: snapshot,
+    writable: false,
+  })
+  return snapshot
+}
+
+export function getRuntimeMermaidSnapshot(nuxtApp: object): ResolvedRuntimeOptions {
+  const snapshot = (nuxtApp as RuntimeSnapshotApp)[runtimeMermaidSnapshotKey]
+  if (!snapshot) {
+    throw new Error(
+      '[nuxt-content-mermaid] Runtime Mermaid Snapshot has not been installed for this NuxtApp',
+    )
+  }
+  return snapshot
+}

--- a/test/builtInRenderer.e2e.test.ts
+++ b/test/builtInRenderer.e2e.test.ts
@@ -90,6 +90,20 @@ describe('built-in renderer integration', async () => {
     ]))
   })
 
+  it('materializes a fresh Mermaid configuration for every render attempt', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+
+    await page.locator('#primary-queue').click()
+    await waitForRuns(page, 2)
+    await releaseNext(page)
+    await page.locator('#primary svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+
+    expect(await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.reusedInitializationConfig
+    })).toBe(false)
+  })
+
   it('preserves the Committed Diagram through failure and pending recovery', { timeout: 20000 }, async () => {
     const page = await createPage()
     await installDiagnosticCapture(page)

--- a/test/fixtures/built-in-renderer/mermaid-stub.ts
+++ b/test/fixtures/built-in-renderer/mermaid-stub.ts
@@ -2,11 +2,13 @@ import type { MermaidConfig } from 'mermaid'
 import type { MermaidControl, MermaidTestWindow } from './types'
 
 const pendingResolvers: Array<() => void> = []
+const initializedConfigs = new WeakSet<object>()
 let currentSecurityLevel: MermaidConfig['securityLevel']
 const control: MermaidControl = {
   pending: 0,
   runs: [],
   stagingRoots: [],
+  reusedInitializationConfig: false,
   releaseNext() {
     pendingResolvers.shift()?.()
   },
@@ -17,6 +19,9 @@ if (typeof window !== 'undefined')
 
 const mermaidStub = {
   initialize: (config: MermaidConfig) => {
+    if (initializedConfigs.has(config))
+      control.reusedInitializationConfig = true
+    initializedConfigs.add(config)
     currentSecurityLevel = config.securityLevel
   },
   render: async (_renderId: string, source: string, stagingTarget?: Element) => {

--- a/test/fixtures/built-in-renderer/types.ts
+++ b/test/fixtures/built-in-renderer/types.ts
@@ -14,6 +14,7 @@ export interface MermaidControl {
   pending: number
   runs: MermaidRun[]
   stagingRoots: HTMLElement[]
+  reusedInitializationConfig: boolean
   lastError?: Error
   releaseNext: () => void
 }

--- a/test/fixtures/runtime-snapshot/app.vue
+++ b/test/fixtures/runtime-snapshot/app.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { useNuxtApp, useRuntimeConfig } from '#app'
+import { getRuntimeMermaidSnapshot } from '../../../src/runtime/runtime-snapshot'
+import { identifySnapshot } from './snapshot-id'
+
+const snapshot = getRuntimeMermaidSnapshot(useNuxtApp())
+const snapshotId = identifySnapshot(snapshot)
+const themeBeforeMutation = snapshot.theme?.light
+const runtimeConfig = useRuntimeConfig()
+const publicPayload = runtimeConfig.public.contentMermaid as {
+  theme: { light: string }
+}
+publicPayload.theme.light = 'forest'
+const themeAfterMutation = snapshot.theme?.light
+const deeplyFrozen = Object.isFrozen(snapshot)
+  && Object.isFrozen(snapshot.theme)
+</script>
+
+<template>
+  <div id="runtime-snapshot">
+    {{ snapshotId }}|{{ themeBeforeMutation }}|{{ themeAfterMutation }}|{{ deeplyFrozen }}
+  </div>
+</template>

--- a/test/fixtures/runtime-snapshot/nuxt.config.ts
+++ b/test/fixtures/runtime-snapshot/nuxt.config.ts
@@ -1,0 +1,14 @@
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [MyModule],
+  compatibilityDate: '2025-11-24',
+  nitro: {
+    compatibilityDate: '2025-11-24',
+  },
+  contentMermaid: {
+    theme: {
+      light: 'neutral',
+    },
+  },
+})

--- a/test/fixtures/runtime-snapshot/package.json
+++ b/test/fixtures/runtime-snapshot/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "runtime-snapshot-fixture",
+  "private": true
+}

--- a/test/fixtures/runtime-snapshot/snapshot-id.ts
+++ b/test/fixtures/runtime-snapshot/snapshot-id.ts
@@ -1,0 +1,11 @@
+const snapshotIds = new WeakMap<object, number>()
+let nextSnapshotId = 0
+
+export function identifySnapshot(snapshot: object): number {
+  const existing = snapshotIds.get(snapshot)
+  if (existing !== undefined) return existing
+
+  nextSnapshotId += 1
+  snapshotIds.set(snapshot, nextSnapshotId)
+  return nextSnapshotId
+}

--- a/test/mermaidClientDebug.test.ts
+++ b/test/mermaidClientDebug.test.ts
@@ -1,39 +1,46 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const mockRuntimeConfig = {
-  public: {
-    contentMermaid: {},
-  },
-}
+import {
+  getRuntimeMermaidSnapshot,
+  installRuntimeMermaidSnapshot,
+} from '../src/runtime/runtime-snapshot'
 
 vi.mock('#app', () => ({
-  defineNuxtPlugin: (fn: () => unknown) => fn(),
-  useRuntimeConfig: () => mockRuntimeConfig,
+  defineNuxtPlugin: (plugin: (nuxtApp: object) => unknown) => plugin,
 }))
 
 const initialize = vi.fn()
+const mermaidInstance = { initialize }
 
 vi.mock('mermaid', () => ({
-  default: {
-    initialize,
-  },
+  default: mermaidInstance,
 }))
 
-describe('mermaid client plugin debug behavior', () => {
+interface MermaidPluginResult {
+  provide: {
+    mermaid: () => Promise<unknown>
+  }
+}
+
+type MermaidPluginFactory = (nuxtApp: object) => unknown
+
+async function createPluginFor(
+  nuxtApp: object,
+  payload: unknown,
+): Promise<MermaidPluginResult> {
+  installRuntimeMermaidSnapshot(nuxtApp, payload)
+  const module = await import('../src/runtime/plugins/mermaid.client')
+  const plugin = module.default as unknown as MermaidPluginFactory
+  return plugin(nuxtApp) as MermaidPluginResult
+}
+
+describe('mermaid client plugin runtime snapshot behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.resetModules()
-    mockRuntimeConfig.public.contentMermaid = {}
-    // Clear cached loader between tests
-    global.__nuxtMermaidLoader__ = undefined
   })
 
-  it('applies debug-friendly defaults when enabled', async () => {
-    mockRuntimeConfig.public.contentMermaid = { debug: true }
-
-    const plugin = await import('../src/runtime/plugins/mermaid.client')
-    // @ts-expect-error - accessing internal provide.mermaid for testing purposes
-    await plugin.default.provide.mermaid()
+  it('applies debug-friendly defaults from the installed snapshot', async () => {
+    const plugin = await createPluginFor({}, { debug: true })
+    await plugin.provide.mermaid()
 
     expect(initialize).toHaveBeenCalledWith(expect.objectContaining({
       logLevel: 1,
@@ -41,32 +48,86 @@ describe('mermaid client plugin debug behavior', () => {
     }))
   })
 
-  it('respects user init overrides even in debug mode', async () => {
-    mockRuntimeConfig.public.contentMermaid = {
+  it('respects explicit init overrides even in debug mode', async () => {
+    const plugin = await createPluginFor({}, {
       debug: true,
-      loader: { init: { logLevel: 3, suppressErrorRendering: true } },
-    }
-
-    const plugin = await import('../src/runtime/plugins/mermaid.client')
-    // @ts-expect-error - accessing internal provide.mermaid for testing purposes
-    await plugin.default.provide.mermaid()
+      loader: { init: { logLevel: 0, suppressErrorRendering: true } },
+    })
+    await plugin.provide.mermaid()
 
     expect(initialize).toHaveBeenCalledWith(expect.objectContaining({
-      logLevel: 3,
+      logLevel: 0,
       suppressErrorRendering: true,
     }))
   })
 
-  it('keeps suppressErrorRendering on when debug is disabled', async () => {
-    mockRuntimeConfig.public.contentMermaid = { debug: false }
-
-    const plugin = await import('../src/runtime/plugins/mermaid.client')
-    // @ts-expect-error - accessing internal provide.mermaid for testing purposes
-    await plugin.default.provide.mermaid()
+  it('keeps error rendering suppressed when debug is disabled', async () => {
+    const plugin = await createPluginFor({}, { debug: false })
+    await plugin.provide.mermaid()
 
     expect(initialize).toHaveBeenCalledWith(expect.objectContaining({
       logLevel: 5,
       suppressErrorRendering: true,
     }))
+  })
+
+  it('does not reread public runtime config after snapshot installation', async () => {
+    const nuxtApp = {}
+    const publicPayload = { debug: false }
+    installRuntimeMermaidSnapshot(nuxtApp, publicPayload)
+    publicPayload.debug = true
+
+    const module = await import('../src/runtime/plugins/mermaid.client')
+    const pluginFactory = module.default as unknown as MermaidPluginFactory
+    const plugin = pluginFactory(nuxtApp) as MermaidPluginResult
+    await plugin.provide.mermaid()
+
+    expect(initialize).toHaveBeenCalledWith(expect.objectContaining({
+      logLevel: 5,
+      suppressErrorRendering: true,
+    }))
+  })
+
+  it('caches per app while keeping separate app initialization state', async () => {
+    const firstPlugin = await createPluginFor({}, { loader: { init: { theme: 'forest' } } })
+    const secondPlugin = await createPluginFor({}, { loader: { init: { theme: 'neutral' } } })
+
+    await Promise.all([
+      firstPlugin.provide.mermaid(),
+      firstPlugin.provide.mermaid(),
+    ])
+    await secondPlugin.provide.mermaid()
+
+    expect(initialize).toHaveBeenCalledTimes(2)
+    expect(initialize).toHaveBeenNthCalledWith(1, expect.objectContaining({ theme: 'forest' }))
+    expect(initialize).toHaveBeenNthCalledWith(2, expect.objectContaining({ theme: 'neutral' }))
+  })
+
+  it('materializes a mutable working copy without mutating the snapshot', async () => {
+    const nuxtApp = {}
+    const plugin = await createPluginFor(nuxtApp, {
+      loader: { init: { themeVariables: { primaryColor: 'blue' } } },
+    })
+    initialize.mockImplementationOnce((config: { themeVariables?: { primaryColor?: string } }) => {
+      if (config.themeVariables) config.themeVariables.primaryColor = 'mutated'
+    })
+
+    await plugin.provide.mermaid()
+
+    const init = getRuntimeMermaidSnapshot(nuxtApp).loader?.init as unknown as {
+      themeVariables: { primaryColor: string }
+    }
+    expect(init.themeVariables.primaryColor).toBe('blue')
+  })
+
+  it('clears a failed app-local load so the next call can retry', async () => {
+    const plugin = await createPluginFor({}, {})
+    initialize.mockImplementationOnce(() => {
+      throw new Error('initialization failed')
+    })
+
+    await expect(plugin.provide.mermaid()).rejects.toThrow('initialization failed')
+    await expect(plugin.provide.mermaid()).resolves.toBe(mermaidInstance)
+    expect(initialize).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/mermaidConfig.test.ts
+++ b/test/mermaidConfig.test.ts
@@ -29,6 +29,32 @@ describe('mermaid config helpers', () => {
     expect(result.startOnLoad).toBe(false)
   })
 
+  it('materializes detached nested structural data for every invocation', () => {
+    const baseConfig = Object.freeze({
+      flowchart: Object.freeze({
+        htmlLabels: true,
+        curve: 'basis',
+      }),
+      secure: Object.freeze(['securityLevel']),
+    }) as unknown as MermaidConfig
+
+    const first = mergeMermaidConfig({ baseConfig })
+    const second = mergeMermaidConfig({ baseConfig })
+
+    expect(first.flowchart).not.toBe(baseConfig.flowchart)
+    expect(first.flowchart).not.toBe(second.flowchart)
+    expect(first.secure).not.toBe(baseConfig.secure)
+    expect(first.secure).not.toBe(second.secure)
+
+    first.flowchart!.htmlLabels = false
+    first.secure!.push('theme')
+
+    expect(baseConfig.flowchart?.htmlLabels).toBe(true)
+    expect(baseConfig.secure).toEqual(['securityLevel'])
+    expect(second.flowchart?.htmlLabels).toBe(true)
+    expect(second.secure).toEqual(['securityLevel'])
+  })
+
   it('selects theme with correct priority', () => {
     expect(
       resolveMermaidTheme({

--- a/test/moduleSetup.test.ts
+++ b/test/moduleSetup.test.ts
@@ -181,6 +181,19 @@ describe('module setup', () => {
     await moduleDef.setup?.({}, nuxt)
 
     expect(addPlugin).toHaveBeenCalled()
+    expect(addPlugin).toHaveBeenCalledTimes(2)
+    const registeredPlugins = addPlugin.mock.calls
+      .map(([plugin]) => plugin)
+      .reverse()
+    expect(registeredPlugins).toEqual([
+      {
+        src: expect.stringContaining('runtime/plugins/runtime-config'),
+      },
+      {
+        src: expect.stringContaining('runtime/plugins/mermaid.client'),
+        mode: 'client',
+      },
+    ])
     expect(addComponent).toHaveBeenCalled()
     expect(addTypeTemplate).toHaveBeenCalled()
     expect(addVitePlugin).toHaveBeenCalledTimes(1)

--- a/test/runtimeConfigPlugin.test.ts
+++ b/test/runtimeConfigPlugin.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getRuntimeMermaidSnapshot } from '../src/runtime/runtime-snapshot'
+
+const state = vi.hoisted(() => ({
+  payload: {} as unknown,
+}))
+
+vi.mock('#app', () => ({
+  defineNuxtPlugin: (plugin: (nuxtApp: object) => unknown) => plugin,
+  useRuntimeConfig: () => ({
+    public: { contentMermaid: state.payload },
+  }),
+}))
+
+type RuntimeConfigPlugin = (nuxtApp: object) => unknown
+
+describe('Universal Runtime Adapter plugin', () => {
+  beforeEach(() => {
+    state.payload = {}
+  })
+
+  it('installs the received public payload once for each app', async () => {
+    const firstApp = {}
+    const secondApp = {}
+    const module = await import('../src/runtime/plugins/runtime-config')
+    const plugin = module.default as unknown as RuntimeConfigPlugin
+
+    state.payload = { theme: { light: 'neutral' } }
+    plugin(firstApp)
+    state.payload = { theme: { light: 'forest' } }
+    plugin(secondApp)
+
+    expect(getRuntimeMermaidSnapshot(firstApp).theme?.light).toBe('neutral')
+    expect(getRuntimeMermaidSnapshot(secondApp).theme?.light).toBe('forest')
+  })
+
+  it('fails initialization without publishing a partial snapshot', async () => {
+    const nuxtApp = {}
+    const module = await import('../src/runtime/plugins/runtime-config')
+    const plugin = module.default as unknown as RuntimeConfigPlugin
+    state.payload = { enabled: true }
+
+    expect(() => plugin(nuxtApp)).toThrowError(
+      expect.objectContaining({ name: 'ContentMermaidConfigurationError' }),
+    )
+    expect(() => getRuntimeMermaidSnapshot(nuxtApp)).toThrow(
+      'Runtime Mermaid Snapshot has not been installed for this NuxtApp',
+    )
+  })
+})

--- a/test/runtimeConfigPlugin.test.ts
+++ b/test/runtimeConfigPlugin.test.ts
@@ -47,4 +47,18 @@ describe('Universal Runtime Adapter plugin', () => {
       'Runtime Mermaid Snapshot has not been installed for this NuxtApp',
     )
   })
+
+  it('rejects an explicit null payload instead of treating it as absent', async () => {
+    const nuxtApp = {}
+    const module = await import('../src/runtime/plugins/runtime-config')
+    const plugin = module.default as unknown as RuntimeConfigPlugin
+    state.payload = null
+
+    expect(() => plugin(nuxtApp)).toThrowError(
+      expect.objectContaining({ name: 'ContentMermaidConfigurationError' }),
+    )
+    expect(() => getRuntimeMermaidSnapshot(nuxtApp)).toThrow(
+      'Runtime Mermaid Snapshot has not been installed for this NuxtApp',
+    )
+  })
 })

--- a/test/runtimeOptions.test.ts
+++ b/test/runtimeOptions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveRuntimeOptionsSnapshot,
+} from '../src/runtime/configuration/runtime-options'
+import { resolveExpandOptions } from '../src/configuration/module'
+
+describe('runtime options snapshot resolver', () => {
+  it('applies runtime and debug defaults before deeply freezing the owned result', () => {
+    const snapshot = resolveRuntimeOptionsSnapshot({})
+
+    expect(snapshot).toMatchObject({
+      debug: false,
+      loader: {
+        init: {
+          logLevel: 5,
+          suppressErrorRendering: true,
+        },
+      },
+      expand: { enabled: true },
+      toolbar: { title: 'mermaid' },
+    })
+    expect(Object.isFrozen(snapshot)).toBe(true)
+    expect(Object.isFrozen(snapshot.loader)).toBe(true)
+    expect(Object.isFrozen(snapshot.loader?.init)).toBe(true)
+    expect(Object.isFrozen(snapshot.expand)).toBe(true)
+    expect(Object.isFrozen(snapshot.toolbar)).toBe(true)
+  })
+
+  it('preserves explicit Mermaid debug values and derives only absent values', () => {
+    const debugSnapshot = resolveRuntimeOptionsSnapshot({ debug: true })
+    const explicitSnapshot = resolveRuntimeOptionsSnapshot({
+      debug: true,
+      loader: {
+        init: {
+          logLevel: 0,
+          suppressErrorRendering: true,
+        },
+      },
+    })
+
+    expect(debugSnapshot.loader?.init).toMatchObject({
+      logLevel: 1,
+      suppressErrorRendering: false,
+    })
+    expect(explicitSnapshot.loader?.init).toMatchObject({
+      logLevel: 0,
+      suppressErrorRendering: true,
+    })
+  })
+
+  it('owns the entire tree while preserving property-presence replacements', () => {
+    const shared = { values: ['shared'] }
+    const payload = {
+      debug: false,
+      loader: {
+        init: {
+          extension: shared,
+          secondExtension: shared,
+          values: [],
+          nullable: null,
+          count: 0,
+          enabled: false,
+          label: '',
+        },
+      },
+      toolbar: {
+        title: '',
+        fontSize: 0,
+        buttons: { copy: false },
+      },
+    }
+
+    const snapshot = resolveRuntimeOptionsSnapshot(payload)
+    const init = snapshot.loader?.init as Record<string, unknown>
+
+    expect(init).toMatchObject({
+      values: [],
+      nullable: null,
+      count: 0,
+      enabled: false,
+      label: '',
+    })
+    expect(snapshot.toolbar).toMatchObject({
+      title: '',
+      fontSize: 0,
+      buttons: { copy: false, fullscreen: true, expand: true },
+    })
+    expect(init.extension).not.toBe(shared)
+    expect(init.secondExtension).not.toBe(shared)
+    expect(init.extension).not.toBe(init.secondExtension)
+    expect(Object.isFrozen(shared)).toBe(false)
+    expect(Object.isFrozen(payload)).toBe(false)
+  })
+
+  it.each([
+    ['absent', [undefined], { enabled: true, margin: 0 }],
+    ['true reset', [{ margin: 99 }, true], { enabled: true, margin: 0 }],
+    ['false reset', [{ margin: 99 }, false], { enabled: false, margin: 0 }],
+    ['empty patch', [false, {}], { enabled: false, margin: 0 }],
+    ['patch without enabled', [false, { margin: 32 }], { enabled: false, margin: 32 }],
+    ['explicit re-enable', [false, { enabled: true, margin: 32 }], { enabled: true, margin: 32 }],
+    ['explicit disable patch', [true, { enabled: false, margin: 32 }], { enabled: false, margin: 32 }],
+  ] as const)('implements the complete expand reset matrix: %s', (_label, layers, expected) => {
+    expect(resolveExpandOptions(layers)).toMatchObject(expected)
+  })
+
+  it('fails at the raw runtime phase without accepting activation', () => {
+    expect(() => resolveRuntimeOptionsSnapshot({ enabled: false })).toThrowError(
+      expect.objectContaining({
+        name: 'ContentMermaidConfigurationError',
+        code: 'CONTENT_MERMAID_CONFIGURATION_ERROR',
+      }),
+    )
+  })
+})

--- a/test/runtimeOptions.test.ts
+++ b/test/runtimeOptions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   resolveRuntimeOptionsSnapshot,
 } from '../src/runtime/configuration/runtime-options'
-import { resolveExpandOptions } from '../src/configuration/module'
+import { resolveExpandOptions, resolveModuleConfiguration } from '../src/configuration/module'
 
 describe('runtime options snapshot resolver', () => {
   it('applies runtime and debug defaults before deeply freezing the owned result', () => {
@@ -45,6 +45,18 @@ describe('runtime options snapshot resolver', () => {
     expect(explicitSnapshot.loader?.init).toMatchObject({
       logLevel: 0,
       suppressErrorRendering: true,
+    })
+  })
+
+  it('derives debug defaults after the real module transport omits absent Mermaid values', () => {
+    const transport = resolveModuleConfiguration({
+      nuxtResolvedOptions: { debug: true },
+      runtimeOverrides: {},
+    }).runtimeOptions
+
+    expect(resolveRuntimeOptionsSnapshot(transport).loader?.init).toMatchObject({
+      logLevel: 1,
+      suppressErrorRendering: false,
     })
   })
 

--- a/test/runtimeSnapshot.e2e.test.ts
+++ b/test/runtimeSnapshot.e2e.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+
+function readSnapshotState(html: string): {
+  id: number
+  before: string
+  after: string
+  frozen: string
+} {
+  const match = html.match(/<div id="runtime-snapshot">\s*(\d+)\|(\w+)\|(\w+)\|(\w+)\s*<\/div>/)
+  if (!match) throw new Error(`Runtime snapshot state was not rendered: ${html}`)
+  return {
+    id: Number(match[1]),
+    before: match[2] ?? '',
+    after: match[3] ?? '',
+    frozen: match[4] ?? '',
+  }
+}
+
+describe('Runtime Mermaid Snapshot SSR ownership', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/runtime-snapshot', import.meta.url)),
+  })
+
+  it('creates a detached deeply frozen snapshot for every SSR render context', async () => {
+    const first = readSnapshotState(await $fetch('/'))
+    const second = readSnapshotState(await $fetch('/'))
+
+    expect(first).toMatchObject({ before: 'neutral', after: 'neutral', frozen: 'true' })
+    expect(second).toMatchObject({ before: 'neutral', after: 'neutral', frozen: 'true' })
+    expect(second.id).not.toBe(first.id)
+  })
+})

--- a/test/runtimeSnapshot.test.ts
+++ b/test/runtimeSnapshot.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { isProxy, reactive } from 'vue'
+import {
+  getRuntimeMermaidSnapshot,
+  installRuntimeMermaidSnapshot,
+} from '../src/runtime/runtime-snapshot'
+
+function expectNoProxy(value: unknown): void {
+  expect(isProxy(value)).toBe(false)
+  if (value === null || typeof value !== 'object') return
+  for (const nested of Object.values(value)) expectNoProxy(nested)
+}
+
+describe('app-scoped Runtime Mermaid Snapshot', () => {
+  it('installs one isolated immutable snapshot on each app', () => {
+    const firstApp = {}
+    const secondApp = {}
+
+    installRuntimeMermaidSnapshot(firstApp, { theme: { light: 'neutral' } })
+    installRuntimeMermaidSnapshot(secondApp, { theme: { light: 'default' } })
+
+    const firstSnapshot = getRuntimeMermaidSnapshot(firstApp)
+    const secondSnapshot = getRuntimeMermaidSnapshot(secondApp)
+
+    expect(firstSnapshot).not.toBe(secondSnapshot)
+    expect(firstSnapshot.theme?.light).toBe('neutral')
+    expect(secondSnapshot.theme?.light).toBe('default')
+
+    installRuntimeMermaidSnapshot(firstApp, { theme: { light: 'forest' } })
+    expect(getRuntimeMermaidSnapshot(firstApp)).toBe(firstSnapshot)
+  })
+
+  it('does not fall back to another app snapshot', () => {
+    const installedApp = {}
+    const missingApp = {}
+
+    installRuntimeMermaidSnapshot(installedApp, {})
+
+    expect(() => getRuntimeMermaidSnapshot(missingApp)).toThrow(
+      'Runtime Mermaid Snapshot has not been installed for this NuxtApp',
+    )
+  })
+
+  it('detaches Vue proxies without freezing or mutating the public payload', () => {
+    const app = {}
+    const payload = reactive({
+      theme: { light: 'neutral' },
+      loader: { init: { extension: { values: ['input'] } } },
+    })
+
+    installRuntimeMermaidSnapshot(app, payload)
+    const snapshot = getRuntimeMermaidSnapshot(app)
+
+    expectNoProxy(snapshot)
+    expect(Object.isFrozen(snapshot)).toBe(true)
+    expect(Object.isFrozen(payload)).toBe(false)
+    expect(Object.isFrozen(payload.theme)).toBe(false)
+
+    payload.theme.light = 'forest'
+    ;(payload.loader.init.extension.values as string[]).push('changed')
+
+    expect(snapshot.theme?.light).toBe('neutral')
+    const extension = snapshot.loader?.init as { extension: { values: readonly string[] } }
+    expect(extension.extension.values).toEqual(['input'])
+  })
+
+  it('publishes nothing when raw validation fails', () => {
+    const app = {}
+
+    expect(() => installRuntimeMermaidSnapshot(app, { enabled: true })).toThrowError(
+      expect.objectContaining({ name: 'ContentMermaidConfigurationError' }),
+    )
+    expect(() => getRuntimeMermaidSnapshot(app)).toThrow(
+      'Runtime Mermaid Snapshot has not been installed for this NuxtApp',
+    )
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    maxWorkers: 2,
     exclude: [
       '**/node_modules/**',
       '**/.git/**',


### PR DESCRIPTION
## Summary

- resolve `runtimeConfig.public.contentMermaid` once per Nuxt app into a detached, validated, deeply frozen runtime snapshot
- register the universal runtime adapter before the client Mermaid loader and make both the loader and built-in renderer consume the app-scoped snapshot
- materialize mutable, structurally detached Mermaid configuration working copies for every initialization/render attempt
- document initialization-time runtime override semantics and add focused unit, SSR, client-loader, and browser coverage

## Validation

- `pnpm lint --fix` — passed
- `pnpm test:types` — passed
- `pnpm test` — 25 files, 169 tests passed
- `pnpm prepack` — build passed
- specification review — passed
- standards review — passed

Closes #26