### PR TITLE
feat: add component source resolver

### DIFF
--- a/src/runtime/component-configuration.ts
+++ b/src/runtime/component-configuration.ts
@@ -1,0 +1,89 @@
+import type { MermaidConfig } from 'mermaid'
+import { assertStrictData, cloneOwnedData } from '../configuration/core'
+import type { PageMermaidConfig } from '../types/config'
+import { PAGE_MERMAID_CONFIG_PHASE } from './constants'
+
+interface MermaidComponentSourceInput {
+  readonly pageConfig?: unknown
+  readonly config?: unknown
+}
+
+export type MermaidComponentSource
+  = | { readonly kind: 'runtime-only' }
+    | { readonly kind: 'page', readonly config: PageMermaidConfig }
+    | { readonly kind: 'direct', readonly config: MermaidConfig }
+    | { readonly kind: 'conflict', readonly error: Error & { readonly code: string } }
+
+class MermaidComponentConfigurationError extends Error {
+  readonly code = 'CONTENT_MERMAID_COMPONENT_CONFIGURATION_ERROR'
+  override readonly name = 'MermaidComponentConfigurationError'
+}
+
+function configurationError(message: string): MermaidComponentConfigurationError {
+  return new MermaidComponentConfigurationError(message)
+}
+
+function ownValue(value: object, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key)
+  return descriptor && 'value' in descriptor ? descriptor.value : undefined
+}
+
+function validateInterpretedPageFields(value: object): void {
+  const theme = ownValue(value, 'theme')
+  if (theme !== undefined && typeof theme !== 'string') {
+    throw configurationError('`pageConfig.theme` must be a string.')
+  }
+
+  const logLevel = ownValue(value, 'logLevel')
+  if (logLevel !== undefined && typeof logLevel !== 'string' && typeof logLevel !== 'number') {
+    throw configurationError('`pageConfig.logLevel` must be a string or number.')
+  }
+
+  const suppressErrorRendering = ownValue(value, 'suppressErrorRendering')
+  if (suppressErrorRendering !== undefined && typeof suppressErrorRendering !== 'boolean') {
+    throw configurationError('`pageConfig.suppressErrorRendering` must be a boolean.')
+  }
+}
+
+function requirePageConfigObject(value: unknown): PageMermaidConfig {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw configurationError('`pageConfig` must be a plain object.')
+  }
+
+  try {
+    assertStrictData(value, PAGE_MERMAID_CONFIG_PHASE)
+  }
+  catch {
+    throw configurationError('`pageConfig` must contain only strict pure data.')
+  }
+
+  validateInterpretedPageFields(value)
+
+  return cloneOwnedData(value) as PageMermaidConfig
+}
+
+function requireDirectConfigObject(value: unknown): MermaidConfig {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw configurationError('`config` must be an object.')
+  }
+  return value as MermaidConfig
+}
+
+export function resolveMermaidComponentSource(
+  input: MermaidComponentSourceInput,
+): MermaidComponentSource {
+  const hasPageConfig = input.pageConfig !== undefined
+  const hasDirectConfig = input.config !== undefined
+
+  if (hasPageConfig && hasDirectConfig) {
+    return {
+      kind: 'conflict',
+      error: configurationError(
+        '`pageConfig` and `config` cannot be supplied together.',
+      ),
+    }
+  }
+  if (hasPageConfig) return { kind: 'page', config: requirePageConfigObject(input.pageConfig) }
+  if (hasDirectConfig) return { kind: 'direct', config: requireDirectConfigObject(input.config) }
+  return { kind: 'runtime-only' }
+}

--- a/src/runtime/components/Mermaid.vue
+++ b/src/runtime/components/Mermaid.vue
@@ -14,6 +14,8 @@ import {
 import { defu } from 'defu'
 import type { Component, ComputedRef } from 'vue'
 import type { MermaidConfig } from 'mermaid'
+import type { MermaidComponentSource } from '../component-configuration'
+import { resolveMermaidComponentSource } from '../component-configuration'
 import { mergeMermaidConfig, resolveMermaidTheme } from '../mermaid-config'
 import { createMermaidRenderer } from '../mermaid-rendering'
 import { getRuntimeMermaidSnapshot } from '../runtime-snapshot'
@@ -29,16 +31,23 @@ import IconFullScreen from './icons/iconFullScreen.vue'
 import IconFullScreenExit from './icons/iconFullScreenExit.vue'
 import MermaidExpandOverlay from './MermaidExpandOverlay.vue'
 import type { MermaidToolbarOptions } from '../../types/mermaid'
+import type { MermaidComponentProps } from '../../types/config'
 import IconExpand from './icons/IconExpand.vue'
 import IconCollapse from './icons/IconCollapse.vue'
 import MermaidFullscreenPresentation from './MermaidFullscreenPresentation.vue'
 
-const props = defineProps<{
-  // Using `unknown` to avoid Vue runtime prop type warnings when user's collection schema is misconfigured; actual validation below.
-  config?: MermaidConfig | string | unknown
-  toolbar?: MermaidToolbarOptions
-  code?: string
-}>()
+const props = defineProps<MermaidComponentProps>()
+
+function resolveCurrentComponentSource() {
+  return resolveMermaidComponentSource({
+    pageConfig: props.pageConfig,
+    config: props.config,
+  })
+}
+
+const initialComponentSource = resolveCurrentComponentSource()
+if (initialComponentSource.kind === 'conflict') throw initialComponentSource.error
+const componentSource = shallowRef<MermaidComponentSource>(initialComponentSource)
 
 const nuxtApp = useNuxtApp()
 const contentMermaidOptions = getRuntimeMermaidSnapshot(nuxtApp)
@@ -174,33 +183,18 @@ const effectiveToolbarFontSizePx = computed(() => {
   return isFullscreen.value ? baseSize * fullscreenToolbarScale.value : baseSize
 })
 
-const pageConfig = computed<MermaidConfig | undefined>(() => {
-  const value = props.config
-  if (!value)
-    return undefined
-
-  if (typeof value !== 'object') {
-    // Only warn if it looks like a schema misconfiguration (received a primitive type)
-    // Skip warning for null or undefined (which are valid when config is optional in schema)
-    if (import.meta.dev && value !== null && value !== undefined) {
-      console.warn(
-        '[nuxt-content-mermaid] Received non-object `config` prop on <Mermaid> component. '
-        + 'This usually means your `content.config.ts` collection schema did not declare `config` as a JSON field. '
-        + 'See README section about per-page overrides via frontmatter.',
-        value,
-      )
-    }
-    return undefined
-  }
-
-  return value as MermaidConfig
+const diagramSourceConfig = computed<MermaidConfig | undefined>(() => {
+  const source = componentSource.value
+  return source.kind === 'runtime-only' || source.kind === 'conflict'
+    ? undefined
+    : source.config as MermaidConfig
 })
 
 const mermaidTheme = computed(() => {
   return resolveMermaidTheme({
     colorModeValue: colorMode?.value,
     manualThemeMode: manualThemeMode.value,
-    frontmatterTheme: pageConfig.value?.theme,
+    frontmatterTheme: diagramSourceConfig.value?.theme,
     baseTheme: baseMermaidInit.theme as MermaidConfig['theme'] | undefined,
     lightTheme,
     darkTheme,
@@ -210,7 +204,7 @@ const mermaidTheme = computed(() => {
 function materializeEffectiveMermaidInit(): MermaidConfig {
   return mergeMermaidConfig({
     baseConfig: baseMermaidInit,
-    overrideConfig: pageConfig.value,
+    overrideConfig: diagramSourceConfig.value,
     theme: mermaidTheme.value,
   })
 }
@@ -250,11 +244,21 @@ let requestBuiltInRender: ReturnType<typeof createMermaidRenderer> | undefined
 function getBuiltInRenderRequest() {
   requestBuiltInRender ??= createMermaidRenderer({
     loadMermaid: $mermaid,
-    readRenderData: () => ({
-      source: mermaidDefinition.value,
-      config: materializeEffectiveMermaidInit(),
-      target: mermaidContainer.value,
-    }),
+    readRenderData: () => {
+      if (componentSource.value.kind === 'conflict') {
+        return {
+          source: null,
+          config: {},
+          target: mermaidContainer.value,
+        }
+      }
+
+      return {
+        source: mermaidDefinition.value,
+        config: materializeEffectiveMermaidInit(),
+        target: mermaidContainer.value,
+      }
+    },
     beforeCommit: () => {
       if (import.meta.client) {
         expandOverlay.value?.endForDiagramReplacement()
@@ -428,6 +432,8 @@ function getMermaidSvg(): SVGSVGElement | null {
 }
 
 async function renderMermaid() {
+  if (componentSource.value.kind === 'conflict') return
+
   isLoading.value = true
 
   const outcome = await getBuiltInRenderRequest()()
@@ -539,15 +545,22 @@ onUnmounted(() => {
   if (copyResetTimer) clearTimeout(copyResetTimer)
 })
 
-watch(mermaidTheme, () => {
-  if (!isEnabled) return
-  if (hasRenderedOnce.value) renderMermaid()
-})
-
 watch(
-  pageConfig,
+  [() => colorMode?.value, manualThemeMode],
   () => {
     if (!isEnabled) return
+    if (componentSource.value.kind === 'conflict') return
+    if (hasRenderedOnce.value) renderMermaid()
+  },
+)
+
+watch(
+  [() => props.pageConfig, () => props.config],
+  () => {
+    const source = resolveCurrentComponentSource()
+    componentSource.value = source
+    if (!isEnabled) return
+    if (source.kind === 'conflict') return
     if (hasRenderedOnce.value) renderMermaid()
   },
   { deep: true },

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -4,6 +4,10 @@ import type { RuntimeMermaidConfig, RuntimeOptions } from '../types/config'
 import type { ExpandOptions } from './types/expand'
 
 export const MERMAID_LOG_PREFIX = '[nuxt-content-mermaid]'
+export const PAGE_MERMAID_CONFIG_PHASE = {
+  name: 'Page Mermaid Config',
+  root: 'pageConfig',
+} as const
 export const DEFAULT_LIGHT_THEME: MermaidConfig['theme'] = 'default'
 export const DEFAULT_DARK_THEME: MermaidConfig['theme'] = 'dark'
 export const FULLSCREEN_ZOOM_HINT_DURATION_MS = 3000

--- a/test/builtInRenderer.e2e.test.ts
+++ b/test/builtInRenderer.e2e.test.ts
@@ -104,6 +104,107 @@ describe('built-in renderer integration', async () => {
     })).toBe(false)
   })
 
+  it('rejects an initial source conflict before creating render work', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+
+    await page.locator('#conflict-mount').click()
+    const fingerprint = page.locator('#component-error')
+    await fingerprint.waitFor({ state: 'attached', timeout: 5000 })
+
+    expect(await fingerprint.getAttribute('data-name')).toBe('MermaidComponentConfigurationError')
+    expect(await fingerprint.getAttribute('data-code')).toBe('CONTENT_MERMAID_COMPONENT_CONFIGURATION_ERROR')
+    expect(await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.runs.length
+    })).toBe(1)
+  })
+
+  it('renders runtime-only and Page Mermaid Config sources through the shared seam', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+
+    await page.locator('#page-config-mount').click()
+    await waitForRuns(page, 2)
+
+    const runs = await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.runs
+    })
+    expect(runs?.[0]).toEqual(expect.objectContaining({
+      theme: 'default',
+      securityLevel: 'strict',
+      unknownMermaidExtensionEnabled: false,
+    }))
+    expect(runs?.[1]).toEqual(expect.objectContaining({
+      theme: 'forest',
+      securityLevel: 'strict',
+      unknownMermaidExtensionEnabled: true,
+    }))
+
+    await releaseNext(page)
+    await page.locator('#page-config svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+  })
+
+  it('revalidates reactive Page Mermaid Config updates through the shared seam', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+    await page.locator('#page-config-mount').click()
+    await waitForRuns(page, 2)
+    await releaseNext(page)
+    await page.locator('#page-config svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+
+    await page.locator('#page-config-invalidate').click()
+    const fingerprint = page.locator('#component-error')
+    await fingerprint.waitFor({ state: 'attached', timeout: 5000 })
+
+    expect(await fingerprint.getAttribute('data-name')).toBe('MermaidComponentConfigurationError')
+    expect(await fingerprint.getAttribute('data-code')).toBe('CONTENT_MERMAID_COMPONENT_CONFIGURATION_ERROR')
+    expect(await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.runs.length
+    })).toBe(2)
+  })
+
+  it('returns a reactive Page Mermaid Config invocation to runtime-only', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+    await page.locator('#page-config-mount').click()
+    await waitForRuns(page, 2)
+    await releaseNext(page)
+    await page.locator('#page-config svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+
+    await page.locator('#page-config-remove').click()
+    await waitForRuns(page, 3)
+    const latestRun = await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.runs[2]
+    })
+    expect(latestRun).toEqual(expect.objectContaining({
+      theme: 'default',
+      securityLevel: 'strict',
+      unknownMermaidExtensionEnabled: false,
+    }))
+
+    await releaseNext(page)
+    await page.locator('#page-config svg[data-run-id="3"]').waitFor({ state: 'visible', timeout: 5000 })
+  })
+
+  it('blocks non-source render triggers during a reactive source conflict', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+    await page.locator('#reactive-conflict-mount').click()
+    await waitForRuns(page, 2)
+    await releaseNext(page)
+    await page.locator('#reactive-conflict svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+
+    await page.locator('#reactive-conflict-enter').click()
+    await page.locator('#reactive-conflict-update-code').click()
+    await page.evaluate(async () => {
+      await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+    })
+
+    expect(await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.runs.length
+    })).toBe(2)
+  })
+
   it('preserves the Committed Diagram through failure and pending recovery', { timeout: 20000 }, async () => {
     const page = await createPage()
     await installDiagnosticCapture(page)

--- a/test/componentConfiguration.test.ts
+++ b/test/componentConfiguration.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { PageMermaidConfig } from '../src/types/config'
+import type { MermaidComponentSource } from '../src/runtime/component-configuration'
+import { resolveMermaidComponentSource } from '../src/runtime/component-configuration'
+
+const componentConfigurationErrorFingerprint = {
+  name: 'MermaidComponentConfigurationError',
+  code: 'CONTENT_MERMAID_COMPONENT_CONFIGURATION_ERROR',
+} as const
+
+function expectComponentConfigurationError(action: () => unknown) {
+  expect(action).toThrow(expect.objectContaining(componentConfigurationErrorFingerprint))
+}
+
+describe('Component Source Resolver', () => {
+  it('distinguishes runtime-only, page, direct, and conflict sources', () => {
+    const pageConfig = { theme: 'forest' } as const
+    const directConfig = { theme: 'dark' } as const
+
+    expect(resolveMermaidComponentSource({})).toEqual({ kind: 'runtime-only' })
+    expect(resolveMermaidComponentSource({ pageConfig })).toEqual({
+      kind: 'page',
+      config: { theme: 'forest' },
+    })
+    expect(resolveMermaidComponentSource({ config: directConfig })).toEqual({
+      kind: 'direct',
+      config: { theme: 'dark' },
+    })
+
+    const conflict = resolveMermaidComponentSource({ pageConfig, config: directConfig })
+    expect(conflict.kind).toBe('conflict')
+  })
+
+  it('reports a source conflict before inspecting either payload', () => {
+    let inspections = 0
+    const pageConfig = Object.defineProperty({}, 'theme', {
+      enumerable: true,
+      get() {
+        inspections += 1
+        return 'forest'
+      },
+    })
+    const directConfig = new Proxy({}, {
+      ownKeys() {
+        inspections += 1
+        return []
+      },
+    })
+
+    const outcome = resolveMermaidComponentSource({ pageConfig, config: directConfig })
+
+    expect(outcome).toEqual({
+      kind: 'conflict',
+      error: expect.objectContaining(componentConfigurationErrorFingerprint),
+    })
+    expect(inspections).toBe(0)
+  })
+
+  it('treats only undefined as absent and rejects null source payloads', () => {
+    expect(resolveMermaidComponentSource({ pageConfig: undefined })).toEqual({
+      kind: 'runtime-only',
+    })
+
+    expectComponentConfigurationError(() => resolveMermaidComponentSource({ pageConfig: null }))
+    expectComponentConfigurationError(() => resolveMermaidComponentSource({ config: null }))
+  })
+
+  it('rejects non-pure page data without invoking accessors', () => {
+    let getterCalls = 0
+    const accessorConfig = Object.defineProperty({}, 'theme', {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        return 'forest'
+      },
+    })
+
+    for (const pageConfig of [
+      { unknownMermaidExtension: { load: () => ({}) } },
+      accessorConfig,
+      new Date(),
+    ]) {
+      expectComponentConfigurationError(() => resolveMermaidComponentSource({ pageConfig }))
+    }
+    expect(getterCalls).toBe(0)
+  })
+
+  it('validates the Mermaid fields interpreted by the package', () => {
+    for (const pageConfig of [
+      { theme: null },
+      { logLevel: false },
+      { suppressErrorRendering: 'yes' },
+    ]) {
+      expectComponentConfigurationError(() => resolveMermaidComponentSource({ pageConfig }))
+    }
+  })
+
+  it('preserves unknown Mermaid-owned pure-data keys', () => {
+    const pageConfig = {
+      unknownMermaidExtension: {
+        enabled: false,
+        values: [null, 1, 'kept'],
+      },
+    }
+
+    expect(resolveMermaidComponentSource({ pageConfig })).toEqual({
+      kind: 'page',
+      config: {
+        unknownMermaidExtension: {
+          enabled: false,
+          values: [null, 1, 'kept'],
+        },
+      },
+    })
+  })
+
+  it('exposes discriminated outcome types to downstream consumers', () => {
+    expectTypeOf<Extract<MermaidComponentSource, { kind: 'page' }>['config']>()
+      .toEqualTypeOf<PageMermaidConfig>()
+    expectTypeOf<Extract<MermaidComponentSource, { kind: 'conflict' }>['error']>()
+      .toMatchTypeOf<Error & { readonly code: string }>()
+  })
+})

--- a/test/fixtures/built-in-renderer/app.vue
+++ b/test/fixtures/built-in-renderer/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onErrorCaptured, reactive, ref, resolveComponent, shallowRef } from 'vue'
 import type { MermaidConfig } from 'mermaid'
+import type { PageMermaidConfig } from '../../../src/types/config'
 
 const primaryVersion = ref(0)
 const primaryCode = ref('graph TD;INITIAL-->DONE')
@@ -10,8 +11,32 @@ const skippedCode = ref('graph TD;SKIPPED-->DONE')
 const showSkipped = ref(false)
 const showStrict = ref(false)
 const showSandbox = ref(false)
+const showPageConfig = ref(false)
+const showConflict = ref(false)
+const showReactiveConflict = ref(false)
+const componentErrorFingerprint = ref<{ name?: string, code?: string } | null>(null)
 const strictConfig: MermaidConfig = { securityLevel: 'strict' }
 const sandboxConfig: MermaidConfig = { securityLevel: 'sandbox' }
+const pageConfig = reactive({
+  theme: 'forest' as const,
+  unknownMermaidExtension: { enabled: true },
+})
+const pageConfigSource = shallowRef<PageMermaidConfig | undefined>(pageConfig)
+const conflictPageConfig = { theme: 'forest' }
+const conflictDirectConfig: MermaidConfig = { theme: 'dark' }
+const reactiveConflictPageConfig = { theme: 'forest' } as const
+const reactiveConflictDirectConfig = shallowRef<MermaidConfig>()
+const reactiveConflictCode = ref('graph TD;REACTIVE_CONFLICT-->LEGAL')
+const MermaidComponent = resolveComponent('Mermaid')
+
+onErrorCaptured((error) => {
+  const fingerprint = error as { name?: string, code?: string }
+  componentErrorFingerprint.value = {
+    name: fingerprint.name,
+    code: fingerprint.code,
+  }
+  return false
+})
 
 const encodedPrimary = computed(() => encodeURIComponent(primaryCode.value))
 const encodedBlocker = computed(() => encodeURIComponent(`graph TD;BLOCKER_${blockerVersion.value}-->DONE`))
@@ -57,6 +82,35 @@ function mountStrict() {
 
 function mountSandbox() {
   showSandbox.value = true
+}
+
+function mountPageConfig() {
+  showPageConfig.value = true
+}
+
+function invalidatePageConfig() {
+  const invalidPageConfig = pageConfig as unknown as { theme: null }
+  invalidPageConfig.theme = null
+}
+
+function removePageConfig() {
+  pageConfigSource.value = undefined
+}
+
+function mountConflict() {
+  showConflict.value = true
+}
+
+function mountReactiveConflict() {
+  showReactiveConflict.value = true
+}
+
+function enterReactiveConflict() {
+  reactiveConflictDirectConfig.value = { theme: 'dark' }
+}
+
+function updateReactiveConflictCode() {
+  reactiveConflictCode.value = 'graph TD;REACTIVE_CONFLICT-->UPDATED'
 }
 </script>
 
@@ -133,6 +187,55 @@ function mountSandbox() {
       >
         Mount sandbox
       </button>
+      <button
+        id="conflict-mount"
+        type="button"
+        @click="mountConflict"
+      >
+        Mount conflict
+      </button>
+      <button
+        id="page-config-mount"
+        type="button"
+        @click="mountPageConfig"
+      >
+        Mount page config
+      </button>
+      <button
+        id="page-config-invalidate"
+        type="button"
+        @click="invalidatePageConfig"
+      >
+        Invalidate page config
+      </button>
+      <button
+        id="page-config-remove"
+        type="button"
+        @click="removePageConfig"
+      >
+        Remove page config
+      </button>
+      <button
+        id="reactive-conflict-mount"
+        type="button"
+        @click="mountReactiveConflict"
+      >
+        Mount reactive conflict
+      </button>
+      <button
+        id="reactive-conflict-enter"
+        type="button"
+        @click="enterReactiveConflict"
+      >
+        Enter reactive conflict
+      </button>
+      <button
+        id="reactive-conflict-update-code"
+        type="button"
+        @click="updateReactiveConflictCode"
+      >
+        Update reactive conflict code
+      </button>
     </div>
 
     <section id="primary">
@@ -172,5 +275,46 @@ function mountSandbox() {
         :config="sandboxConfig"
       />
     </section>
+
+    <section
+      v-if="showConflict"
+      id="conflict"
+    >
+      <component
+        :is="MermaidComponent"
+        :code="encodeURIComponent('graph TD;CONFLICT-->DONE')"
+        :page-config="conflictPageConfig"
+        :config="conflictDirectConfig"
+      />
+    </section>
+
+    <section
+      v-if="showPageConfig"
+      id="page-config"
+    >
+      <Mermaid
+        :code="encodeURIComponent('graph TD;PAGE-->DONE')"
+        :page-config="pageConfigSource"
+      />
+    </section>
+
+    <section
+      v-if="showReactiveConflict"
+      id="reactive-conflict"
+    >
+      <component
+        :is="MermaidComponent"
+        :code="encodeURIComponent(reactiveConflictCode)"
+        :page-config="reactiveConflictPageConfig"
+        :config="reactiveConflictDirectConfig"
+      />
+    </section>
+
+    <output
+      v-if="componentErrorFingerprint"
+      id="component-error"
+      :data-name="componentErrorFingerprint.name"
+      :data-code="componentErrorFingerprint.code"
+    />
   </main>
 </template>

--- a/test/fixtures/built-in-renderer/mermaid-stub.ts
+++ b/test/fixtures/built-in-renderer/mermaid-stub.ts
@@ -4,6 +4,8 @@ import type { MermaidControl, MermaidTestWindow } from './types'
 const pendingResolvers: Array<() => void> = []
 const initializedConfigs = new WeakSet<object>()
 let currentSecurityLevel: MermaidConfig['securityLevel']
+let currentTheme: MermaidConfig['theme']
+let currentUnknownMermaidExtensionEnabled = false
 const control: MermaidControl = {
   pending: 0,
   runs: [],
@@ -23,6 +25,10 @@ const mermaidStub = {
       control.reusedInitializationConfig = true
     initializedConfigs.add(config)
     currentSecurityLevel = config.securityLevel
+    currentTheme = config.theme
+    currentUnknownMermaidExtensionEnabled
+      = (config as MermaidConfig & { unknownMermaidExtension?: { enabled?: boolean } })
+        .unknownMermaidExtension?.enabled === true
   },
   render: async (_renderId: string, source: string, stagingTarget?: Element) => {
     const id = control.runs.length + 1
@@ -33,7 +39,9 @@ const mermaidStub = {
     control.runs.push({
       source,
       id,
+      theme: currentTheme,
       securityLevel: currentSecurityLevel,
+      unknownMermaidExtensionEnabled: currentUnknownMermaidExtensionEnabled,
       stagingConnected: stagingTarget?.isConnected === true,
       stagingHidden: stagingRoot?.getAttribute('aria-hidden') === 'true',
       stagingInert: stagingRoot?.inert === true && stagingRoot.style.pointerEvents === 'none',

--- a/test/fixtures/built-in-renderer/types.ts
+++ b/test/fixtures/built-in-renderer/types.ts
@@ -3,7 +3,9 @@ import type { MermaidConfig } from 'mermaid'
 export interface MermaidRun {
   source: string
   id: number
+  theme: MermaidConfig['theme']
   securityLevel: MermaidConfig['securityLevel']
+  unknownMermaidExtensionEnabled: boolean
   stagingConnected: boolean
   stagingHidden: boolean
   stagingInert: boolean


### PR DESCRIPTION
## Summary

- add one shared Component Source Resolver for runtime-only, Page Mermaid Config, Direct Mermaid Config, and conflict outcomes
- validate and detach Page Mermaid Config while preserving unknown Mermaid-owned pure-data keys
- route initial and reactive component inputs through the resolver and block conflict-driven render work
- cover source classification, type narrowing, initial/reactive conflicts, runtime-only recovery, and rendered Page Mermaid Config

Closes #27

## Verification

- `pnpm lint`
- `pnpm test:types`
- `pnpm test` — 26 files, 181 tests passed
- `pnpm test:package-contract` — prepack build and package type contract passed