### PR TITLE
feat!: route Markdown config through pageConfig

### DIFF
--- a/docs/superpowers/plans/2026-08-03-markdown-page-config.md
+++ b/docs/superpowers/plans/2026-08-03-markdown-page-config.md
@@ -1,0 +1,69 @@
+# Markdown Page Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry Content-authored Mermaid configuration through the Markdown Diagram Protocol as `pageConfig`, preserving supported Markdown behavior and selective fallback.
+
+**Architecture:** Keep Markdown-owned inputs at the transform boundary. Classify Mermaid YAML frontmatter, fence inline attributes, toolbar metadata, and diagram configuration in named resolvers; validate and normalize each source before applying property-presence merge. The transform emits `:page-config="config"`, which the existing shared component source resolver consumes as Page Mermaid Config.
+
+**Tech Stack:** TypeScript, Nuxt Content/MDC, Mermaid, Vitest, `@nuxt/test-utils`.
+
+## Global Constraints
+
+- Generated Markdown uses `pageConfig`; direct component use retains `config`.
+- Unsupported or recognized-invalid fence metadata falls back to the original fence; unexpected transform defects propagate.
+- Markdown/Mermaid-owned configuration remains open pure data; package-owned toolbar and inline attribute schemas are closed.
+- Apply Property-Presence Merge only after per-source classification and normalization; preserve explicit falsy values, `null`, and array replacement semantics.
+
+---
+
+### Task 1: Establish protocol contract tests (TDD) ✅
+
+**Files:**
+- Modify: `test/transformMermaid.test.ts`
+- Modify: `test/markdownDiagramProtocol.test.ts`
+
+1. Add assertions that transformed supported fences bind `:page-config="config"` and never `:config="config"`.
+2. Add protocol coverage for multiple diagrams, source/config/toolbar semantics, and local fallback for invalid metadata.
+3. Run the focused tests and confirm the new assertions fail before implementation.
+
+### Task 2: Introduce named Markdown metadata resolvers ✅
+
+**Files:**
+- Create: `src/markdown-diagram-transform/configuration.ts`
+- Modify: `src/markdown-diagram-transform/metadata.ts`
+- Modify: `test/transformMermaid.test.ts`
+
+1. Define resolver boundaries for Mermaid frontmatter, inline fence attributes, toolbar, and diagram Mermaid config.
+2. Normalize accepted inputs, validate ownership-specific schemas, and apply property-presence merge only to normalized values.
+3. Preserve unknown Mermaid-owned pure-data keys; reject closed-schema metadata and use a signal that selects the original Markdown fence.
+4. Run the transform test file after every red-green loop.
+
+### Task 3: Switch the generated protocol binding ✅
+
+**Files:**
+- Modify: `src/markdown-diagram-transform.ts`
+- Modify: `test/transformMermaid.test.ts`
+- Modify: `test/markdownDiagramProtocol.test.ts`
+
+1. Replace the generated direct `config` binding with the `pageConfig` binding.
+2. Route parsed metadata through the named resolvers and make selective fallback atomic: do not generate partial component markup.
+3. Preserve non-target Markdown, empty/unsupported fences, indentation, and existing accepted metadata behavior.
+
+### Task 4: Validate Nuxt Content parsing and rendered output ✅
+
+**Files:**
+- Modify: `test/markdownDiagramProtocol.test.ts`
+- Modify: `test/builtInRenderer.e2e.test.ts` only if the fixture requires additional coverage
+
+1. Verify MDC parses generated markup into the component, diagram source, page configuration, toolbar, and fallback behavior without relying on exact serialization.
+2. Verify an emitted page config is consumed by the built-in renderer through the existing Page Mermaid Config source path.
+3. Run focused transform/protocol/fixture tests, then lint, full Vitest suite, type checks, and the package build gate.
+
+### Task 5: Review and publish
+
+**Files:** all task-related files above
+
+1. Review the diff against issue #28 and repository standards on independent spec and standards axes.
+2. Fix confirmed findings and rerun affected checks.
+3. Commit the planned scope, push the feature branch, create a PR linked to `Fixes #28`, and squash merge it into `main` after green checks.

--- a/src/markdown-diagram-transform.ts
+++ b/src/markdown-diagram-transform.ts
@@ -1,16 +1,18 @@
 import type { MermaidToolbarOptions } from './types/mermaid'
 import {
-  applyMermaidFrontmatterOverrides,
-  extractMermaidInlineOverrides,
-  extractToolbarProps,
-  mergeToolbarProps,
+  applyResolvedMermaidFrontmatter,
+  inspectMermaidFrontmatter,
   parseInlineAttrs,
-  parseMermaidFrontmatter,
 } from './markdown-diagram-transform/metadata'
+import {
+  resolveFenceInlineAttributes,
+  resolveMarkdownFrontmatter,
+  resolveMarkdownToolbar,
+} from './markdown-diagram-transform/configuration'
 import { isNonEmptyRecord } from './runtime/utils/is'
 
 const MERMAID_COMPONENT_NAME = 'Mermaid'
-const PAGE_MERMAID_CONFIG_BINDING = 'config'
+const PAGE_MERMAID_CONFIG_EXPRESSION = 'config'
 
 function serializeInlineAttributeRecord(value: Record<string, unknown>) {
   return JSON.stringify(value)
@@ -81,7 +83,7 @@ export function transformMarkdownDiagrams(body: string) {
 
   const buildComponentTag = (encoded: string, toolbar?: MermaidToolbarOptions) => {
     const attrs = [
-      `:config="${PAGE_MERMAID_CONFIG_BINDING}"`,
+      `:page-config="${PAGE_MERMAID_CONFIG_EXPRESSION}"`,
     ]
 
     if (toolbar && isNonEmptyRecord(toolbar)) {
@@ -146,16 +148,47 @@ export function transformMarkdownDiagrams(body: string) {
     }
 
     const inlineAttrs = parseInlineAttrs(fence.info)
-    const frontmatterInfo = parseMermaidFrontmatter(rawCode, newline)
-    const inlineOverrides = extractMermaidInlineOverrides(inlineAttrs)
-    const mergedCode = inlineOverrides
-      ? applyMermaidFrontmatterOverrides(rawCode, newline, frontmatterInfo, inlineOverrides, fence.indent)
-      : rawCode
+    if (fence.info.includes('{') && !inlineAttrs) {
+      output.push(...lines.slice(index, closingIndex + 1))
+      index = closingIndex
+      continue
+    }
 
-    const toolbarProps = mergeToolbarProps(
-      extractToolbarProps(frontmatterInfo?.data),
-      extractToolbarProps(inlineAttrs),
-    )
+    const frontmatterResult = inspectMermaidFrontmatter(rawCode, newline)
+    if (frontmatterResult.kind === 'invalid') {
+      output.push(...lines.slice(index, closingIndex + 1))
+      index = closingIndex
+      continue
+    }
+    const frontmatterInfo = frontmatterResult.kind === 'valid'
+      ? frontmatterResult.info
+      : null
+
+    const inlineOverrides = resolveFenceInlineAttributes(inlineAttrs)
+    if (inlineAttrs && !inlineOverrides) {
+      output.push(...lines.slice(index, closingIndex + 1))
+      index = closingIndex
+      continue
+    }
+
+    const resolvedFrontmatter = resolveMarkdownFrontmatter([
+      frontmatterInfo?.data,
+      inlineOverrides ?? undefined,
+    ])
+    const toolbarProps = resolveMarkdownToolbar([
+      frontmatterInfo?.data.toolbar,
+      inlineOverrides?.toolbar,
+    ])
+    if (resolvedFrontmatter === null || toolbarProps === null) {
+      output.push(...lines.slice(index, closingIndex + 1))
+      index = closingIndex
+      continue
+    }
+
+    const hasInlineOverrides = inlineOverrides && Object.keys(inlineOverrides).length > 0
+    const mergedCode = frontmatterInfo || hasInlineOverrides
+      ? applyResolvedMermaidFrontmatter(rawCode, newline, frontmatterInfo, resolvedFrontmatter, fence.indent)
+      : rawCode
 
     const encoded = encodeURIComponent(mergedCode.trim())
     output.push(`${fence.indent}${buildComponentTag(encoded, toolbarProps)}`)

--- a/src/markdown-diagram-transform/configuration.ts
+++ b/src/markdown-diagram-transform/configuration.ts
@@ -1,0 +1,191 @@
+import {
+  ContentMermaidConfigurationError,
+  assertStrictData,
+  cloneOwnedData,
+  mergeByPresence,
+  type ConfigurationValidationPhase,
+} from '../configuration/core'
+import type { JsonObject, JsonValue } from '../types/config'
+import type { MermaidToolbarOptions } from '../types/mermaid'
+
+const MARKDOWN_METADATA_PHASE = {
+  name: 'Markdown Mermaid Metadata',
+  root: 'mermaid',
+} as const satisfies ConfigurationValidationPhase
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+const INLINE_ATTRIBUTE_KEYS = new Set(['title', 'displayMode', 'config', 'toolbar'])
+const TOOLBAR_KEYS = new Set(['title', 'fontSize', 'fullscreenToolbarScale', 'buttons'])
+const TOOLBAR_BUTTON_KEYS = new Set(['copy', 'fullscreen', 'expand'])
+
+function hasOwn(value: JsonObject, key: string) {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function valueAt(value: JsonObject, key: string): JsonValue | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key)
+  return descriptor && 'value' in descriptor ? descriptor.value as JsonValue : undefined
+}
+
+function isPlainRecord(value: JsonValue): value is JsonObject {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function hasUnsafeKeys(value: JsonValue): boolean {
+  if (value === null || typeof value !== 'object') return false
+
+  const descriptors = Object.getOwnPropertyDescriptors(value)
+  for (const key of Object.keys(descriptors)) {
+    if (UNSAFE_KEYS.has(key)) return true
+
+    const descriptor = descriptors[key]
+    if (descriptor && 'value' in descriptor && hasUnsafeKeys(descriptor.value as JsonValue))
+      return true
+  }
+
+  return false
+}
+
+function normalizeRecord(value: unknown): JsonObject | null {
+  try {
+    assertStrictData(value, MARKDOWN_METADATA_PHASE)
+  }
+  catch (error) {
+    if (error instanceof ContentMermaidConfigurationError) return null
+    throw error
+  }
+
+  if (!isPlainRecord(value) || hasUnsafeKeys(value)) return null
+
+  return cloneOwnedData(value)
+}
+
+function hasOnlyKeys(value: JsonObject, allowedKeys: ReadonlySet<string>): boolean {
+  return Object.keys(Object.getOwnPropertyDescriptors(value)).every(key => allowedKeys.has(key))
+}
+
+function isStringifiableScalar(value: JsonValue): value is string | number | boolean | null {
+  return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+}
+
+function normalizeToolbar(value: unknown): MermaidToolbarOptions | null {
+  const toolbar = normalizeRecord(value)
+  if (!toolbar || !hasOnlyKeys(toolbar, TOOLBAR_KEYS)) return null
+
+  const title = valueAt(toolbar, 'title')
+  if (title !== undefined && typeof title !== 'string') return null
+
+  const fontSize = valueAt(toolbar, 'fontSize')
+  if (fontSize !== undefined && typeof fontSize !== 'string' && typeof fontSize !== 'number') return null
+
+  const fullscreenToolbarScale = valueAt(toolbar, 'fullscreenToolbarScale')
+  if (fullscreenToolbarScale !== undefined && typeof fullscreenToolbarScale !== 'number') return null
+
+  const buttons = valueAt(toolbar, 'buttons')
+  if (buttons !== undefined) {
+    if (!isPlainRecord(buttons) || !hasOnlyKeys(buttons, TOOLBAR_BUTTON_KEYS)) return null
+    for (const key of TOOLBAR_BUTTON_KEYS) {
+      const button = valueAt(buttons, key)
+      if (button !== undefined && typeof button !== 'boolean') return null
+    }
+  }
+
+  return toolbar as MermaidToolbarOptions
+}
+
+/**
+ * Validates an open Mermaid-owned page payload without discarding extension keys.
+ */
+export function resolveDiagramMermaidConfig(value: unknown): JsonObject | null {
+  return normalizeRecord(value)
+}
+
+/**
+ * Validates and normalizes the closed authoring syntax on a Mermaid fence.
+ */
+export function resolveFenceInlineAttributes(
+  value: Record<string, unknown> | null,
+): JsonObject | null {
+  if (value === null) return null
+
+  const attrs = normalizeRecord(value)
+  if (!attrs || !hasOnlyKeys(attrs, INLINE_ATTRIBUTE_KEYS)) return null
+
+  const normalized = cloneOwnedData(attrs)
+  for (const key of ['title', 'displayMode'] as const) {
+    if (!hasOwn(attrs, key)) continue
+
+    const attribute = valueAt(attrs, key)
+    if (attribute === undefined || !isStringifiableScalar(attribute)) return null
+    normalized[key] = String(attribute)
+  }
+
+  if (hasOwn(attrs, 'config')) {
+    const config = resolveDiagramMermaidConfig(valueAt(attrs, 'config'))
+    if (!config) return null
+    normalized.config = config
+  }
+
+  if (hasOwn(attrs, 'toolbar')) {
+    const toolbar = resolveMarkdownToolbar([valueAt(attrs, 'toolbar')])
+    if (toolbar === null || toolbar === undefined) return null
+    normalized.toolbar = toolbar
+  }
+
+  return normalized
+}
+
+/**
+ * Resolves open Mermaid YAML frontmatter only after every source has normalized.
+ */
+export function resolveMarkdownFrontmatter(
+  layers: readonly (Record<string, unknown> | undefined)[],
+): JsonObject | null {
+  const normalizedLayers: JsonObject[] = []
+
+  for (const layer of layers) {
+    if (layer === undefined) continue
+
+    const normalized = normalizeRecord(layer)
+    if (!normalized) return null
+
+    if (hasOwn(normalized, 'config')) {
+      const config = resolveDiagramMermaidConfig(valueAt(normalized, 'config'))
+      if (!config) return null
+      normalized.config = config
+    }
+
+    if (hasOwn(normalized, 'toolbar')) {
+      const toolbar = resolveMarkdownToolbar([valueAt(normalized, 'toolbar')])
+      if (toolbar === null || toolbar === undefined) return null
+      normalized.toolbar = toolbar
+    }
+
+    normalizedLayers.push(normalized)
+  }
+
+  return mergeByPresence(normalizedLayers)
+}
+
+/**
+ * Resolves closed package-owned toolbar metadata without applying runtime defaults.
+ */
+export function resolveMarkdownToolbar(
+  layers: readonly unknown[],
+): MermaidToolbarOptions | undefined | null {
+  const normalizedLayers: JsonObject[] = []
+
+  for (const layer of layers) {
+    if (layer === undefined) continue
+
+    const toolbar = normalizeToolbar(layer)
+    if (!toolbar) return null
+    normalizedLayers.push(toolbar as JsonObject)
+  }
+
+  if (!normalizedLayers.length) return undefined
+  return mergeByPresence(normalizedLayers) as MermaidToolbarOptions
+}

--- a/src/markdown-diagram-transform/metadata.ts
+++ b/src/markdown-diagram-transform/metadata.ts
@@ -1,7 +1,6 @@
-import { defu } from 'defu'
 import destr from 'destr'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
-import { isNonEmptyRecord, isRecord } from '../runtime/utils/is'
+import { isRecord } from '../runtime/utils/is'
 
 // Prevent prototype pollution via inline attribute paths.
 const UNSAFE_INLINE_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
@@ -13,14 +12,12 @@ export type MermaidFrontmatterInfo = {
   indent: string
 }
 
-export type MermaidInlineOverrides = {
-  title?: string
-  displayMode?: string
-  config?: Record<string, unknown>
-  toolbar?: Record<string, unknown>
-}
+export type MermaidFrontmatterParseResult
+  = | { kind: 'absent' }
+    | { kind: 'invalid' }
+    | { kind: 'valid', info: MermaidFrontmatterInfo }
 
-export function parseMermaidFrontmatter(rawCode: string, newline: string): MermaidFrontmatterInfo | null {
+export function inspectMermaidFrontmatter(rawCode: string, newline: string): MermaidFrontmatterParseResult {
   const lines = rawCode.split(newline)
   let startIndex = 0
 
@@ -47,11 +44,11 @@ export function parseMermaidFrontmatter(rawCode: string, newline: string): Merma
   }
 
   if (startIndex >= lines.length)
-    return null
+    return { kind: 'absent' }
 
   const startLine = lines[startIndex]!
   if (startLine.trim() !== '---')
-    return null
+    return { kind: 'absent' }
 
   const indentMatch = startLine.match(/^\s*/)
   const indent = indentMatch ? indentMatch[0] : ''
@@ -65,7 +62,7 @@ export function parseMermaidFrontmatter(rawCode: string, newline: string): Merma
   }
 
   if (endIndex === -1)
-    return null
+    return { kind: 'invalid' }
 
   const yamlLines = lines
     .slice(startIndex + 1, endIndex)
@@ -75,18 +72,26 @@ export function parseMermaidFrontmatter(rawCode: string, newline: string): Merma
   try {
     const data = yamlRaw ? parseYaml(yamlRaw) : {}
     if (!isRecord(data))
-      return null
+      return { kind: 'invalid' }
 
     return {
-      data,
-      startIndex,
-      endIndex,
-      indent,
+      kind: 'valid',
+      info: {
+        data,
+        startIndex,
+        endIndex,
+        indent,
+      },
     }
   }
   catch {
-    return null
+    return { kind: 'invalid' }
   }
+}
+
+export function parseMermaidFrontmatter(rawCode: string, newline: string): MermaidFrontmatterInfo | null {
+  const result = inspectMermaidFrontmatter(rawCode, newline)
+  return result.kind === 'valid' ? result.info : null
 }
 
 function isMermaidDirectiveStart(line: string) {
@@ -110,7 +115,7 @@ function skipMermaidDirective(lines: string[], startIndex: number) {
 
 export function parseInlineAttrs(info: string): Record<string, unknown> | null {
   const attrsBlock = extractInlineAttrsBlock(info)
-  if (!attrsBlock)
+  if (attrsBlock === null)
     return null
 
   return parseInlineAttrsBlock(attrsBlock)
@@ -153,7 +158,7 @@ function extractInlineAttrsBlock(info: string): string | null {
   return null
 }
 
-function parseInlineAttrsBlock(raw: string): Record<string, unknown> {
+function parseInlineAttrsBlock(raw: string): Record<string, unknown> | null {
   const result: Record<string, unknown> = {}
   let index = 0
 
@@ -182,7 +187,8 @@ function parseInlineAttrsBlock(raw: string): Record<string, unknown> {
       value = parseAttributeValue(rawValue, quoted)
     }
 
-    setNestedValue(result, key, value)
+    if (!setNestedValue(result, key, value))
+      return null
   }
 
   return result
@@ -333,17 +339,17 @@ function parseStructuredValue(value: string) {
 function setNestedValue(target: Record<string, unknown>, path: string, value: unknown) {
   const keys = path.split('.').filter(Boolean)
   if (!keys.length)
-    return
+    return false
 
   let current = target
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]!
     if (UNSAFE_INLINE_KEYS.has(key))
-      return
+      return false
 
     if (i === keys.length - 1) {
       current[key] = value
-      return
+      return true
     }
 
     const existing = current[key]
@@ -352,55 +358,18 @@ function setNestedValue(target: Record<string, unknown>, path: string, value: un
     }
     current = current[key] as Record<string, unknown>
   }
+
+  return true
 }
-
-export function extractToolbarProps(source: Record<string, unknown> | null | undefined) {
-  if (!source)
-    return undefined
-
-  return isRecord(source.toolbar) ? source.toolbar : undefined
-}
-
-export function extractMermaidInlineOverrides(source: Record<string, unknown> | null): MermaidInlineOverrides | null {
-  if (!source)
-    return null
-
-  const overrides: MermaidInlineOverrides = {}
-  let hasOverrides = false
-
-  if (source.title !== undefined) {
-    overrides.title = String(source.title)
-    hasOverrides = true
-  }
-
-  if (source.displayMode !== undefined) {
-    overrides.displayMode = String(source.displayMode)
-    hasOverrides = true
-  }
-
-  if (isRecord(source.config)) {
-    overrides.config = source.config
-    hasOverrides = true
-  }
-
-  if (isRecord(source.toolbar)) {
-    overrides.toolbar = source.toolbar
-    hasOverrides = true
-  }
-
-  return hasOverrides ? overrides : null
-}
-
-export function applyMermaidFrontmatterOverrides(
+export function applyResolvedMermaidFrontmatter(
   rawCode: string,
   newline: string,
   frontmatterInfo: MermaidFrontmatterInfo | null,
-  overrides: MermaidInlineOverrides,
+  frontmatter: Record<string, unknown>,
   fallbackIndent: string,
 ) {
-  const mergedFrontmatter = mergeMermaidFrontmatter(frontmatterInfo?.data, overrides)
   const frontmatterLines = serializeMermaidFrontmatter(
-    mergedFrontmatter,
+    frontmatter,
     frontmatterInfo?.indent ?? fallbackIndent,
   )
 
@@ -416,44 +385,6 @@ export function applyMermaidFrontmatterOverrides(
     ...frontmatterLines,
     ...lines,
   ].join(newline)
-}
-
-function mergeMermaidFrontmatter(
-  existing: Record<string, unknown> | undefined,
-  overrides: MermaidInlineOverrides,
-) {
-  const merged = existing ? { ...existing } : {}
-
-  if (overrides.title !== undefined)
-    merged.title = overrides.title
-
-  if (overrides.displayMode !== undefined)
-    merged.displayMode = overrides.displayMode
-
-  if (overrides.config && isRecord(overrides.config)) {
-    const baseConfig = isRecord(merged.config) ? merged.config : undefined
-    merged.config = defu({}, overrides.config, baseConfig || {})
-  }
-
-  if (overrides.toolbar && isRecord(overrides.toolbar)) {
-    const baseToolbar = isRecord(merged.toolbar) ? merged.toolbar : undefined
-    merged.toolbar = defu({}, overrides.toolbar, baseToolbar || {})
-  }
-
-  return merged
-}
-
-export function mergeToolbarProps(
-  yamlToolbar: Record<string, unknown> | undefined,
-  inlineToolbar: Record<string, unknown> | undefined,
-) {
-  const merged = defu(
-    {},
-    inlineToolbar || {},
-    yamlToolbar || {},
-  )
-
-  return isNonEmptyRecord(merged) ? merged : undefined
 }
 
 function serializeMermaidFrontmatter(frontmatter: Record<string, unknown>, indent: string) {

--- a/test/builtInRenderer.e2e.test.ts
+++ b/test/builtInRenderer.e2e.test.ts
@@ -144,6 +144,28 @@ describe('built-in renderer integration', async () => {
     await page.locator('#page-config svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
   })
 
+  it('renders Content-authored Markdown through the Page Mermaid Config protocol', { timeout: 20000 }, async () => {
+    const page = await createPage()
+    await renderInitialDiagram(page)
+
+    expect(await page.locator('#markdown-page-status').getAttribute('data-loaded')).toBe('true')
+    await page.locator('#markdown-page-config-mount').click()
+    await waitForRuns(page, 2)
+
+    const markdownRun = await page.evaluate(() => {
+      return (window as MermaidTestWindow).__mermaidControl__?.runs[1]
+    })
+    expect(markdownRun).toEqual(expect.objectContaining({
+      source: expect.stringContaining('MARKDOWN_PAGE_CONFIG'),
+      theme: 'forest',
+      securityLevel: 'strict',
+      unknownMermaidExtensionEnabled: true,
+    }))
+
+    await releaseNext(page)
+    await page.locator('#markdown-page-config svg[data-run-id="2"]').waitFor({ state: 'visible', timeout: 5000 })
+  })
+
   it('revalidates reactive Page Mermaid Config updates through the shared seam', { timeout: 20000 }, async () => {
     const page = await createPage()
     await renderInitialDiagram(page)

--- a/test/fixtures/built-in-renderer/app.vue
+++ b/test/fixtures/built-in-renderer/app.vue
@@ -1,7 +1,22 @@
 <script setup lang="ts">
+import { useAsyncData } from '#app'
 import { computed, onErrorCaptured, reactive, ref, resolveComponent, shallowRef } from 'vue'
 import type { MermaidConfig } from 'mermaid'
 import type { PageMermaidConfig } from '../../../src/types/config'
+
+type MarkdownPage = {
+  path: string
+  config?: PageMermaidConfig
+  body: unknown
+}
+
+declare const queryCollection: (collection: 'content') => {
+  path: (path: string) => {
+    select: (...fields: string[]) => {
+      first: () => Promise<MarkdownPage | null>
+    }
+  }
+}
 
 const primaryVersion = ref(0)
 const primaryCode = ref('graph TD;INITIAL-->DONE')
@@ -12,6 +27,7 @@ const showSkipped = ref(false)
 const showStrict = ref(false)
 const showSandbox = ref(false)
 const showPageConfig = ref(false)
+const showMarkdownPageConfig = ref(false)
 const showConflict = ref(false)
 const showReactiveConflict = ref(false)
 const componentErrorFingerprint = ref<{ name?: string, code?: string } | null>(null)
@@ -28,6 +44,9 @@ const reactiveConflictPageConfig = { theme: 'forest' } as const
 const reactiveConflictDirectConfig = shallowRef<MermaidConfig>()
 const reactiveConflictCode = ref('graph TD;REACTIVE_CONFLICT-->LEGAL')
 const MermaidComponent = resolveComponent('Mermaid')
+const { data: markdownPage } = await useAsyncData('markdown-page-config', () =>
+  queryCollection('content').path('/markdown-page-config').select('path', 'config', 'body').first(),
+)
 
 onErrorCaptured((error) => {
   const fingerprint = error as { name?: string, code?: string }
@@ -86,6 +105,10 @@ function mountSandbox() {
 
 function mountPageConfig() {
   showPageConfig.value = true
+}
+
+function mountMarkdownPageConfig() {
+  showMarkdownPageConfig.value = true
 }
 
 function invalidatePageConfig() {
@@ -202,6 +225,13 @@ function updateReactiveConflictCode() {
         Mount page config
       </button>
       <button
+        id="markdown-page-config-mount"
+        type="button"
+        @click="mountMarkdownPageConfig"
+      >
+        Mount Markdown page config
+      </button>
+      <button
         id="page-config-invalidate"
         type="button"
         @click="invalidatePageConfig"
@@ -299,6 +329,16 @@ function updateReactiveConflictCode() {
     </section>
 
     <section
+      v-if="showMarkdownPageConfig"
+      id="markdown-page-config"
+    >
+      <ContentRenderer
+        v-if="markdownPage"
+        :value="markdownPage"
+      />
+    </section>
+
+    <section
       v-if="showReactiveConflict"
       id="reactive-conflict"
     >
@@ -315,6 +355,11 @@ function updateReactiveConflictCode() {
       id="component-error"
       :data-name="componentErrorFingerprint.name"
       :data-code="componentErrorFingerprint.code"
+    />
+    <output
+      id="markdown-page-status"
+      :data-loaded="String(Boolean(markdownPage))"
+      :data-path="markdownPage?.path"
     />
   </main>
 </template>

--- a/test/fixtures/built-in-renderer/content.config.ts
+++ b/test/fixtures/built-in-renderer/content.config.ts
@@ -1,0 +1,13 @@
+import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+
+export default defineContentConfig({
+  collections: {
+    content: defineCollection({
+      type: 'page',
+      source: '**',
+      schema: z.object({
+        config: z.record(z.unknown()).optional(),
+      }),
+    }),
+  },
+})

--- a/test/fixtures/built-in-renderer/content/markdown-page-config.md
+++ b/test/fixtures/built-in-renderer/content/markdown-page-config.md
@@ -1,0 +1,11 @@
+---
+config:
+  theme: forest
+  unknownMermaidExtension:
+    enabled: true
+---
+
+```mermaid
+graph TD
+  MARKDOWN_PAGE_CONFIG --> RENDERED
+```

--- a/test/markdownDiagramProtocol.test.ts
+++ b/test/markdownDiagramProtocol.test.ts
@@ -70,7 +70,8 @@ describe('Markdown Diagram Protocol', () => {
     const diagram = parseDiagramFrontmatter(protocol.source)
 
     expect(protocol.component?.tag).toBe('mermaid')
-    expect(protocol.props[':config']).toBe('config')
+    expect(protocol.props[':page-config']).toBe('config')
+    expect(protocol.props).not.toHaveProperty(':config')
     expect(protocol.parsed.data.config).toEqual({
       theme: 'neutral',
       flowchart: {
@@ -107,7 +108,7 @@ describe('Markdown Diagram Protocol', () => {
     ])
   })
 
-  it('preserves invalid Mermaid YAML Frontmatter as a local fallback', async () => {
+  it('preserves invalid Mermaid YAML Frontmatter as original Markdown', async () => {
     const markdown = [
       '```mermaid',
       '---',
@@ -119,16 +120,17 @@ describe('Markdown Diagram Protocol', () => {
       '',
     ].join('\n')
 
-    const protocol = await parseProtocol(markdown)
+    const parsed = await parseMarkdown(transformMarkdownDiagrams(markdown), { highlight: false })
 
-    expect(protocol.source.replace(/\r\n/g, '\n').split('\n').map(line => line.trim()).filter(Boolean)).toEqual([
-      '---',
-      'title: [invalid',
-      '---',
-      'graph TD',
-      'A --> B',
-    ])
-    expect(protocol.props[':config']).toBe('config')
-    expect(protocol.props).not.toHaveProperty(':toolbar')
+    expect(parsed.body.children).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'element',
+        tag: 'pre',
+        props: expect.objectContaining({ code: expect.stringContaining('title: [invalid') }),
+      }),
+    ]))
+    expect(parsed.body.children).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'element', tag: 'mermaid' }),
+    ]))
   })
 })

--- a/test/transformMermaid.test.ts
+++ b/test/transformMermaid.test.ts
@@ -6,6 +6,11 @@ import { parse as parseYaml } from 'yaml'
 import { parseMarkdown } from '@nuxtjs/mdc/runtime'
 import type { MDCElement } from '@nuxtjs/mdc'
 import { transformMarkdownDiagrams } from '../src/markdown-diagram-transform'
+import {
+  resolveFenceInlineAttributes,
+  resolveMarkdownFrontmatter,
+  resolveMarkdownToolbar,
+} from '../src/markdown-diagram-transform/configuration'
 
 describe('transformMarkdownDiagrams', () => {
   const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), 'fixtures/transform')
@@ -41,7 +46,7 @@ describe('transformMarkdownDiagrams', () => {
     return (data && typeof data === 'object') ? data as Record<string, unknown> : null
   }
 
-  it('wraps mermaid code blocks with Mermaid component and config binding', () => {
+  it('wraps mermaid code blocks with Mermaid component and Page Mermaid Config binding', () => {
     const body = [
       '# Diagram',
       '```mermaid',
@@ -53,14 +58,15 @@ describe('transformMarkdownDiagrams', () => {
 
     const output = transformMarkdownDiagrams(body)
 
-    expect(output).toContain('<Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
+    expect(output).toContain('<Mermaid :page-config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
+    expect(output).not.toContain(':config="config"')
   })
 
   it('transforms multiple mermaid blocks in a single document', () => {
     const body = loadFixture('multiple-blocks.md')
     const output = transformMarkdownDiagrams(body)
 
-    const matches = output.match(/<Mermaid :config="config" code="/g) || []
+    const matches = output.match(/<Mermaid :page-config="config" code="/g) || []
     expect(matches.length).toBe(2)
     expect(output).toContain('graph%20TD%0A%20%20A%5BStart%5D%20--%3E%20B%7BChoice%7D')
     expect(output).toContain('sequenceDiagram%0A%20%20participant%20Alice')
@@ -75,6 +81,18 @@ describe('transformMarkdownDiagrams', () => {
 
     const output = transformMarkdownDiagrams(body)
     expect(output).toBe(body)
+  })
+
+  it('preserves supported empty inline attribute syntax', () => {
+    const body = [
+      '```mermaid {}',
+      'graph TD',
+      '  A --> B',
+      '```',
+      '',
+    ].join('\n')
+
+    expect(transformMarkdownDiagrams(body)).toContain('<Mermaid :page-config="config"')
   })
 
   it('preserves non-target Markdown exactly', () => {
@@ -146,7 +164,7 @@ describe('transformMarkdownDiagrams', () => {
     expect(() => transformMarkdownDiagrams(body)).toThrow()
   })
 
-  it('transforms mermaid fences with info string attributes', () => {
+  it('returns the original fence for unsupported info string attributes', () => {
     const body = [
       '# Diagram',
       '```mermaid {background:#ff0; border:2px solid #f00;}',
@@ -156,8 +174,7 @@ describe('transformMarkdownDiagrams', () => {
       '',
     ].join('\n')
 
-    const output = transformMarkdownDiagrams(body)
-    expect(output).toContain('<Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
+    expect(transformMarkdownDiagrams(body)).toBe(body)
   })
 
   it('extracts toolbar props from mermaid YAML frontmatter', async () => {
@@ -202,7 +219,7 @@ describe('transformMarkdownDiagrams', () => {
     })
   })
 
-  it('falls back to raw code when mermaid YAML frontmatter is invalid', async () => {
+  it('returns the original fence when mermaid YAML frontmatter is invalid', () => {
     const body = [
       '```mermaid',
       '---',
@@ -215,16 +232,9 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    const decoded = extractDecodedCode(output)
 
-    expect(decoded).toBe([
-      '---',
-      'title: [invalid',
-      '---',
-      'graph TD',
-      '  A --> B',
-    ].join('\n'))
-    expect(await extractToolbarProp(output)).toBeNull()
+    expect(output).toBe(body)
+    expect(output).not.toContain('<Mermaid')
   })
 
   it('does not map YAML title to toolbar title', async () => {
@@ -246,7 +256,7 @@ describe('transformMarkdownDiagrams', () => {
     expect(await extractToolbarProp(output)).toBeNull()
   })
 
-  it('ignores unsafe inline attrs like __proto__ in toolbar overrides', async () => {
+  it('returns the original fence for unsafe inline attribute paths', () => {
     const body = [
       '```mermaid {toolbar.__proto__="polluted" toolbar.title="Safe Title"}',
       'graph TD',
@@ -256,9 +266,7 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(await extractToolbarProp(output)).toEqual({
-      title: 'Safe Title',
-    })
+    expect(output).toBe(body)
     expect(({} as { polluted?: unknown }).polluted).toBeUndefined()
   })
 
@@ -321,7 +329,7 @@ describe('transformMarkdownDiagrams', () => {
     })
   })
 
-  it('preserves metadata precedence while filtering unsafe inline paths', async () => {
+  it('returns the original fence instead of partially transforming unsafe metadata', () => {
     const body = [
       '```mermaid {title="Inline Title" displayMode="compact" toolbar.fontSize="18px" toolbar.constructor.polluted=true config=\'{"theme":"forest"}\'}',
       '---',
@@ -341,32 +349,7 @@ describe('transformMarkdownDiagrams', () => {
       '',
     ].join('\n')
 
-    const output = transformMarkdownDiagrams(body)
-
-    expect(await extractToolbarProp(output)).toEqual({
-      title: 'YAML Toolbar',
-      fontSize: '18px',
-      buttons: {
-        copy: false,
-      },
-    })
-    expect(extractFrontmatter(extractDecodedCode(output))).toEqual({
-      title: 'Inline Title',
-      displayMode: 'compact',
-      toolbar: {
-        title: 'YAML Toolbar',
-        fontSize: '18px',
-        buttons: {
-          copy: false,
-        },
-      },
-      config: {
-        theme: 'forest',
-        flowchart: {
-          htmlLabels: false,
-        },
-      },
-    })
+    expect(transformMarkdownDiagrams(body)).toBe(body)
   })
 
   it('moves frontmatter above mermaid directives before rendering', () => {
@@ -423,7 +406,7 @@ describe('transformMarkdownDiagrams', () => {
     ].join('\n')
 
     const output = transformMarkdownDiagrams(body)
-    expect(output).toContain('  <Mermaid :config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
+    expect(output).toContain('  <Mermaid :page-config="config" code="graph%20TD%0A%20%20A%20--%3E%20B"></Mermaid>')
   })
 
   it('does not transform mermaid fences inside other fenced code blocks', () => {
@@ -472,5 +455,87 @@ describe('transformMarkdownDiagrams', () => {
     const output = transformMarkdownDiagrams(body)
     expect(output).toContain('graph%20TD%0D%0A%20%20A%20--%3E%20B')
     expect(output).not.toMatch(/(^|[^\r])\n/)
+  })
+
+  it('preserves open Markdown and Mermaid configuration keys with property-presence precedence', () => {
+    const body = [
+      '```mermaid {config=\'{"extension":{"array":["inline"],"enabled":false,"limit":0,"label":""}}\'}',
+      '---',
+      'unknownMarkdownKey: retained',
+      'config:',
+      '  unknownMermaidKey:',
+      '    preserved: true',
+      '  extension:',
+      '    array: [yaml]',
+      '    enabled: true',
+      '    limit: 1',
+      '    label: YAML',
+      '---',
+      'graph TD',
+      '  A --> B',
+      '```',
+      '',
+    ].join('\n')
+
+    expect(extractFrontmatter(extractDecodedCode(transformMarkdownDiagrams(body)))).toEqual({
+      unknownMarkdownKey: 'retained',
+      config: {
+        unknownMermaidKey: { preserved: true },
+        extension: {
+          array: ['inline'],
+          enabled: false,
+          limit: 0,
+          label: '',
+        },
+      },
+    })
+  })
+
+  it.each([
+    ['unknown inline attributes', ['```mermaid {unknown=true}']],
+    ['unknown toolbar keys', ['```mermaid', '---', 'toolbar:', '  unsupported: true', '---']],
+    ['null toolbar values', ['```mermaid', '---', 'toolbar: null', '---']],
+  ])('returns the original fence for %s', (_name, openingLines) => {
+    const body = [
+      ...openingLines,
+      'graph TD',
+      '  A --> B',
+      '```',
+      '',
+    ].join('\n')
+
+    expect(transformMarkdownDiagrams(body)).toBe(body)
+  })
+
+  it('rejects accessor metadata without invoking it', () => {
+    let reads = 0
+    const inlineAttrs = Object.defineProperty({}, 'title', {
+      enumerable: true,
+      get() {
+        reads += 1
+        return 'never read'
+      },
+    })
+
+    expect(resolveFenceInlineAttributes(inlineAttrs)).toBeNull()
+    expect(reads).toBe(0)
+  })
+
+  it('exposes separate normalized Markdown metadata resolvers', () => {
+    const frontmatter = resolveMarkdownFrontmatter([
+      { config: { extension: { array: ['yaml'], enabled: true } } },
+      { config: { extension: { array: ['inline'], enabled: false } } },
+    ])
+
+    expect(frontmatter).toEqual({
+      config: { extension: { array: ['inline'], enabled: false } },
+    })
+    expect(resolveMarkdownToolbar([
+      { title: 'YAML Toolbar' },
+      { fontSize: '18px' },
+    ])).toEqual({
+      title: 'YAML Toolbar',
+      fontSize: '18px',
+    })
   })
 })


### PR DESCRIPTION
## 摘要

- 將 Markdown Mermaid fence 的設定改以 `pageConfig` 協定傳遞。
- 以具名 resolver 驗證並合併 frontmatter、inline attributes 與 toolbar；已辨識的不合法輸入會完整回退至原始 fence。
- 新增 Markdown → Nuxt Content → ContentRenderer 的端對端覆蓋。

## 驗證

- `pnpm test`（26 files、189 tests）
- `pnpm test:types`
- `pnpm lint`
- `pnpm prepack`
- `pnpm dev:build`

Fixes #28